### PR TITLE
Moar dev deploy fixes

### DIFF
--- a/.github/workflows/deploy_to_github_io.yml
+++ b/.github/workflows/deploy_to_github_io.yml
@@ -29,7 +29,7 @@ jobs:
           cd hyp3-docs
           # Remove conflicting CNAME for project site
           rm docs/CNAME
-          mkdocs gh-deploy
+          mkdocs gh-deploy --force
 
       - uses: actions/checkout@v2
         if: github.ref == 'refs/heads/main'
@@ -43,4 +43,4 @@ jobs:
         shell: bash -l {0}
         run: |
           cd ASFHyP3.github.io
-          mkdocs gh-deploy --config-file ../hyp3-docs/mkdocs.yml --remote-branch main
+          mkdocs gh-deploy  --force --config-file ../hyp3-docs/mkdocs.yml --remote-branch main

--- a/.github/workflows/deploy_to_github_io.yml
+++ b/.github/workflows/deploy_to_github_io.yml
@@ -27,6 +27,8 @@ jobs:
         shell: bash -l {0}
         run: |
           cd hyp3-docs
+          # Remove conflicting CNAME for project site
+          rm docs/CNAME
           mkdocs gh-deploy
 
       - uses: actions/checkout@v2


### PR DESCRIPTION
Remove the CNAME file from the dev site so we don't get GitHub Pages warnings like:

![image](https://user-images.githubusercontent.com/7882693/111364201-cb809880-8645-11eb-9475-6f0293d9441d.png)


Also, add force option to deploy [as recommended](https://squidfunk.github.io/mkdocs-material/publishing-your-site/) by our base theme