### PR TITLE
Add redirect for removed RTC product guide PDF

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,3 +73,4 @@ plugins:
         #    See: https://github.com/datarobot/mkdocs-redirects/issues/16
         getting_started.md: 'https://hyp3-docs.asf.alaska.edu/#getting-started'
         using/vertex.md: 'https://search.asf.alaska.edu/#/?topic=onDemand'
+        guides/Sentinel_RTC_Product_Guide.pdf: guides/rtc_product_guide.md


### PR DESCRIPTION
Current pdf link: https://hyp3-docs.asf.alaska.edu/guides/Sentinel_RTC_Product_Guide.pdf

Watch the redirect in the dev site: https://hyp3-docs.asf.alaska.edu/hyp3-docs/guides/Sentinel_RTC_Product_Guide.pdf