### PR TITLE
Add tag action

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,65 @@
+name: Tag release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.TOOLS_BOT_PAK }}
+
+      - name: Get associated PR
+        uses: helaili/github-graphql-action@2.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
+        with:
+          query: .github/queries/asssociated-pr.query.yml
+          outputFile: pr.json
+          owner: ASFHyP3
+          name: hyp3-docs
+          sha: ${{ github.sha }}
+
+      - name: Get PR labels
+        uses: helaili/github-graphql-action@2.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
+        with:
+          query: .github/queries/pr-labels.query.yml
+          outputFile: labels.json
+          owner: ASFHyP3
+          name: hyp3-docs
+
+      - name: Upload query artifacts for debugging
+        uses: actions/upload-artifact@v2
+        with:
+          name: query-responces
+          path: '*.json'
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install bump2version
+      - name: Tag version
+        run: |
+          git fetch origin +refs/tags/*:refs/tags/*
+          git config user.email "UAF-asf-apd@alaska.edu"
+          git config user.name "tools-bot"
+          LABEL_QUERY='.data.repository.pullRequest.labels.nodes[].name'
+          SELECT='select(. == "major" or . == "minor" or . == "patch")'
+          BUMP_PART=$(jq --raw-output  "${LABEL_QUERY} | ${SELECT}" labels.json | sort | head -1)
+          PR_QUERY='.data.repository.commit.associatedPullRequests.edges[0].node.title'
+          TAG_MSG=$(jq --raw-output "${PR_QUERY}"  pr.json)
+          bump2version --current-version $(git describe --abbrev=0) \
+              --tag --tag-message "${TAG_MSG}" "${BUMP_PART}"
+          git push --tags
+          echo "Tagged version $(git describe --abbrev=0) and pushed back to repo"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,4 +1,4 @@
-name: Test and build
+name: Test build of website
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
       - develop
 
 jobs:
-  build_and_deploy:
+  test_build:
     name: Test build of site
     runs-on: "ubuntu-latest"
     steps:


### PR DESCRIPTION
Our typical test and build workflow works on [PRs and Pushes to main/develop](https://github.com/ASFHyP3/hyp3-sdk/blob/develop/.github/workflows/test-and-tag.yml#L3-L11). 

The test workflow here only currently works on PRs to main/develop, so this adds a separate workflow to tag on pushes to main. 

Instead, we could do this on PRs to main *when they are closed* [ala DISCO](https://github.com/asfadmin/Discovery-WKTUtils/blob/devel/.github/workflows/prod-request-merged.yml) but I don't yet know how to:
* Filter specific labels and sort them

which allows us protect against PRs that accidentally have multiple "bump" tags. Would just need to play with the github events context... 