### PR TITLE
Fix trufflehog last tag export

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Scan for secrets with trufflehog
         run: |
           git fetch origin +refs/tags/*:refs/tags/*
-           export LAST_TAG_HASH=$(git rev-list -1 $(git describe --abbrev=0))
+          export LAST_TAG_HASH=$(git rev-list -1 $(git describe --abbrev=0))
           trufflehog --regex --entropy True --since_commit "${LAST_TAG_HASH}" \
               --exclude_paths .trufflehog.txt file://"${PWD}"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -27,11 +27,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install trufflehog gitdb2=="2.*"
+          python -m pip install trufflehog
 
       - name: Scan for secrets with trufflehog
         run: |
           git fetch origin +refs/tags/*:refs/tags/*
-          export LAST_TAG_HASH=$(git show-ref --hash -- $(git describe --abbrev=0))
+           export LAST_TAG_HASH=$(git rev-list -1 $(git describe --abbrev=0))
           trufflehog --regex --entropy True --since_commit "${LAST_TAG_HASH}" \
               --exclude_paths .trufflehog.txt file://"${PWD}"


### PR DESCRIPTION
This should make is so  trufflehog will stop complaining, and will actually only look back to the last release