### PR TITLE
Clarify that we do not offer atmospheric correction options

### DIFF
--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -236,7 +236,7 @@ The local incidence angle is defined as the angle between the incident radar sig
 The baseline is defined as the difference of the platform positions when a given area is imaged. HyP3 baselines are calculated using the best state vectors available. These are either restituted or precise. **If no restituted or precise state vectors are available, the process will not run**.
 
 ## Error Sources
-There are a number of potential sources for error in InSAR products, and these may be present in the On Demand products. We do not currently offer the option to apply corrections to On Demand InSAR products, but further processing or time series analysis can be performed by the user to identify or reduce the impact of errors when using InSAR for analysis. 
+On Demand InSAR products do not currently correct for some common sources of error in interferometry, such as atmospheric effects. Further processing or time series analysis can be performed by the user to identify or reduce the impact of some of these errors when using On Demand InSAR products for analysis.
 
 ### Atmospheric Delay
 While SAR signals can penetrate clouds, atmospheric conditions can delay the transmission of the signal. This results in phase differences that can look like surface deformation signals, but are actually driven by differences in the atmospheric conditions between the pair of acquisitions used to generate the interferogram. 

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -236,6 +236,7 @@ The local incidence angle is defined as the angle between the incident radar sig
 The baseline is defined as the difference of the platform positions when a given area is imaged. HyP3 baselines are calculated using the best state vectors available. These are either restituted or precise. **If no restituted or precise state vectors are available, the process will not run**.
 
 ## Error Sources
+There are a number of potential sources for error in InSAR products, and these may be present in the On Demand products. We do not currently offer the option to apply corrections to On Demand InSAR products, but further processing or time series analysis can be performed by the user to identify or reduce the impact of errors when using InSAR for analysis. 
 
 ### Atmospheric Delay
 While SAR signals can penetrate clouds, atmospheric conditions can delay the transmission of the signal. This results in phase differences that can look like surface deformation signals, but are actually driven by differences in the atmospheric conditions between the pair of acquisitions used to generate the interferogram. 

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -40,24 +40,11 @@ The term *baseline* refers to the physical distance between the two vantage poin
 
 To monitor surface deformation, the perpendicular baseline for the two acquisitions should be very small in order to maximize the coherence of the phase measurements. 
 
-In order to determine topography, two slightly different vantage points are required. Sensitivity to topography depends on the perpendicular baseline, the sensor wavelength, the distance between the satellite and the ground, and the sensor look angle as given in equation 1. The parameters are diagrammed in Figure 3. 
+In order to determine topography, two slightly different vantage points are required. Sensitivity to topography depends on the perpendicular baseline, the sensor wavelength, the distance between the satellite and the ground, and the sensor look angle.
 
 ![Figure 2](../images/baseline.png "Geometry of InSAR Baselines.")
 
 *Figure 2: Geometry of InSAR baselines. Two satellite passes image the same area on the ground from positions S1 and S2, resulting a baseline of B which can be decomposed into normal (B<sub>n</sub>) and perpendicular (B<sub>p</sub>) components. Here Y is the direction of travel or *along-track* and X is the direction perpendicular to motion, referred to as the *cross-track* or *range* direction. Credit: Franz J. Meyer*
-
---------
-
-![Equation 1](../images/phi_topo_eq.png "Equation 1: Calculation of topographic phase")
-
-*Equation 1: Calculation of topographic phase*
-
---------
-
-
-![Figure 3](../images/baseline2.png "Parameters Affecting Topographic Sensitivity")
-
-*Figure 3: Parameters affecting topographic sensitivity include the perpendicular baseline B&#8869, the wavelength  of the sensor &#955, the distance from the sensor to the ground R, and the sensor look angle &#952. Credit: Franz J. Meyer*
 
 #### Temporal Baseline
 In contrast to the (physical) baseline, the *temporal baseline* refers to the time separation between imaging passes. Along-track interferometry measures motion in the millisecond to second range. This technique can detect ocean currents and rapidly moving objects like boats. Differential interferometry is the standard method used to detect motion in the range of days to years. This is the type of interferometry that is performed by the Sentinel-1 HyP3 InSAR processing algorithm. Table 1 lists different temporal baselines, their common names, and what they can be used to measure.  

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -40,11 +40,24 @@ The term *baseline* refers to the physical distance between the two vantage poin
 
 To monitor surface deformation, the perpendicular baseline for the two acquisitions should be very small in order to maximize the coherence of the phase measurements. 
 
-In order to determine topography, two slightly different vantage points are required. Sensitivity to topography depends on the perpendicular baseline, the sensor wavelength, the distance between the satellite and the ground, and the sensor look angle.
+In order to determine topography, two slightly different vantage points are required. Sensitivity to topography depends on the perpendicular baseline, the sensor wavelength, the distance between the satellite and the ground, and the sensor look angle as given in equation 1. The parameters are diagrammed in Figure 3. 
 
 ![Figure 2](../images/baseline.png "Geometry of InSAR Baselines.")
 
 *Figure 2: Geometry of InSAR baselines. Two satellite passes image the same area on the ground from positions S1 and S2, resulting a baseline of B which can be decomposed into normal (B<sub>n</sub>) and perpendicular (B<sub>p</sub>) components. Here Y is the direction of travel or *along-track* and X is the direction perpendicular to motion, referred to as the *cross-track* or *range* direction. Credit: Franz J. Meyer*
+
+--------
+
+![Equation 1](../images/phi_topo_eq.png "Equation 1: Calculation of topographic phase")
+
+*Equation 1: Calculation of topographic phase*
+
+--------
+
+
+![Figure 3](../images/baseline2.png "Parameters Affecting Topographic Sensitivity")
+
+*Figure 3: Parameters affecting topographic sensitivity include the perpendicular baseline B&#8869, the wavelength  of the sensor &#955, the distance from the sensor to the ground R, and the sensor look angle &#952. Credit: Franz J. Meyer*
 
 #### Temporal Baseline
 In contrast to the (physical) baseline, the *temporal baseline* refers to the time separation between imaging passes. Along-track interferometry measures motion in the millisecond to second range. This technique can detect ocean currents and rapidly moving objects like boats. Differential interferometry is the standard method used to detect motion in the range of days to years. This is the type of interferometry that is performed by the Sentinel-1 HyP3 InSAR processing algorithm. Table 1 lists different temporal baselines, their common names, and what they can be used to measure.  


### PR DESCRIPTION
In the error section, we mention that it is possible to apply an atmospheric correction to the data. This change clarifies that we do not offer any of those corrections as part of the On Demand processing. 

It would be great if we could link to other software that can be used to perform these corrections on the GAMMA-generated products. Is it appropriate to add in links to GACOS http://www.gacos.net/ or TRAIN http://davidbekaert.com/download/TRAIN_manual.pdf 

I would LOVE to have a workflow or guidance that walks though using the HyP3 InSAR products in an atmospheric correction workflow. 