### PR TITLE
Table wrap option

### DIFF
--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -241,7 +241,7 @@ The tags and extensions used and example file names for each raster are listed i
 | _corr.tif | Normalized coherence file | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_corr.tif |
 | _unw_phase.tif | Unwrapped geocoded interferogram | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_unw_phase.tif |
 | _wrapped_phase.tif | Wrapped geocoded interogram | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_wrapped_phase.tif |
-| _los__disp.tif | Line-of-sight displacement | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_los_disp.tif |
+| _los_disp.tif | Line-of-sight displacement | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_los_disp.tif |
 | _vert_disp.tif | Vertical displacement | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_vert_disp.tif |
 | _lv_phi.tif | Look vector &#966 | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_lv_phi.tif |
 | _lv_theta.tif | Look vector &#952 | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_lv_theta.tif |

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -237,21 +237,21 @@ The tags and extensions used and example file names for each raster are listed i
 
 | Extension | Description | Example |
 |---|---|---|
-| _amp.tif | Amplitude | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_amp.tif |
-| _corr.tif | Normalized coherence file | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_corr.tif |
-| _unw_phase.tif | Unwrapped geocoded interferogram | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_unw_phase.tif |
-| _wrapped_phase.tif | Wrapped geocoded interogram | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_wrapped_phase.tif |
-| _los__disp.tif | Line-of-sight displacement | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_los_disp.tif |
-| _vert_disp.tif | Vertical displacement | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_vert_disp.tif |
-| _lv_phi.tif | Look vector &#966 | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_lv_phi.tif |
-| _lv_theta.tif | Look vector &#952 | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_lv_theta.tif |
-| _dem.tif | Digital elevation model | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_dem.tif |
-| _mask.tif | Water mask | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_mask.tif |
-| _inc_map.tif | Incidence angle | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_inc_map.tif |
-| _color_phase.kmz | Wrapped phase kmz file | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_color_phase.kmz |
-| _unw_phase.kmz | Unwrapped phase kmz file | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_unw_phase.kmz |
-| _color_phase.png | Wrapped phase browse image | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_color_phase.png |
-| _unw_phase.png | Unwrapped phase browse image | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_unw_phase.png |
+| _amp.tif | Amplitude | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_amp.tif |
+| _corr.tif | Normalized coherence file | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_corr.tif |
+| _unw_phase.tif | Unwrapped geocoded interferogram | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_unw_phase.tif |
+| _wrapped_phase.tif | Wrapped geocoded interogram | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_wrapped_phase.tif |
+| _los__disp.tif | Line-of-sight displacement | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_los_disp.tif |
+| _vert_disp.tif | Vertical displacement | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_vert_disp.tif |
+| _lv_phi.tif | Look vector &#966 | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_lv_phi.tif |
+| _lv_theta.tif | Look vector &#952 | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_lv_theta.tif |
+| _dem.tif | Digital elevation model | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_dem.tif |
+| _mask.tif | Water mask | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_mask.tif |
+| _inc_map.tif | Incidence angle | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_inc_map.tif |
+| _color_phase.kmz | Wrapped phase kmz file | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_color_phase.kmz |
+| _unw_phase.kmz | Unwrapped phase kmz file | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_unw_phase.kmz |
+| _color_phase.png | Wrapped phase browse image | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_color_phase.png |
+| _unw_phase.png | Unwrapped phase browse image | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_unw_phase.png |
 
 *Table 2: Image files in product package*
 
@@ -261,9 +261,9 @@ Along with the image files, there are currently two text files - the main readme
 
 | Extension | Description | Example |
 |-----------|-------------|---------|
-| png.aux.xml | Geolocation information for png browse images | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09_color_phase.png.aux.xml |
-| .txt | Useful metadata fields for the InSAR pair | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09.txt |
-| .README.md.txt | Main README file for GAMMA InSAR | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09.README.md.txt |
+| png.aux.xml | Geolocation information for png browse images | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>_color_phase.png.aux.xml |
+| .txt | Useful metadata fields for the InSAR pair | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>.txt |
+| .README.md.txt | Main README file for GAMMA InSAR | S1AB_20171111T150004_20171117T145926_VVP006_INT80_G_ueF_4D09<br>.README.md.txt |
 
 *Table 3: Metadata files in product package*
 


### PR DESCRIPTION
This is one option for wrapping the table of sample filenames. 
Benefit: it's consistent
Drawback: it's not adaptive for those who are looking at smaller screens

I did find that I had to make my browser pretty narrow before it became an issue (the sidebar to the left goes away before the table has to crunch down), so this might be workable? 