### PR TITLE
Re-organize table of contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Added "InSAR Product Guide" page
 
 ### Changed
+* Re-organized site table of contents
+* Moved product usage guidelines from Products page to a new Usage Guidelines page
 * Updated status of Copernicus DEM in RTC Product Guide and DEM reference page
 
 ## [0.2.2](https://github.com/ASFHyP3/hyp3-docs/compare/v0.2.1...v0.2.2)

--- a/docs/products.md
+++ b/docs/products.md
@@ -47,14 +47,3 @@ visit the ITS_LIVE project website.
 A Digital Elevation Model (DEM) is required for autoRIFT processing. ASF uses the
 best publicly-available DEM with full coverage of the processing area. To learn more,
 visit [Digital Elevation Models](dems.md).
-
-## Product usage guidelines
-
-When using this data in a publication or presentation, we ask that you include the
-acknowledgement provided with each product. DOIs are also provided for citation
-when discussing the HyP3 software or plugins.
-
-- For multi-file products, the acknowledgement and relevant DOIs are included in
-  the `*.README.md.txt` file.
-- For netCDF products, the acknowledgement is included in the `source` global attribute
-  and the DOIs are included in the `references` global attribute.

--- a/docs/usage_guidelines.md
+++ b/docs/usage_guidelines.md
@@ -1,0 +1,10 @@
+# Product Usage Guidelines
+
+When using this data in a publication or presentation, we ask that you include the
+acknowledgement provided with each product. DOIs are also provided for citation
+when discussing the HyP3 software or plugins.
+
+- For multi-file products, the acknowledgement and relevant DOIs are included in
+  the `*.README.md.txt` file.
+- For netCDF products, the acknowledgement is included in the `source` global attribute
+  and the DOIs are included in the `references` global attribute.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,8 +54,8 @@ nav:
   - SAR Basics:
     - guides/introduction_to_sar.md
     - Introduction to SAR: guides/introduction_to_sar.md
-    - SAR FAQ: https://asf.alaska.edu/information/sar-information/what-is-sar/#sar_faq" target="_blank
     - Digital Elevation Models: dems.md
+    - SAR FAQ: https://asf.alaska.edu/information/sar-information/what-is-sar/#sar_faq" target="_blank
   - Other Tools:
     - ArcGIS Toolbox: tools/arcgis_toolbox.md
     - ASF Tools for Python:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,33 +31,39 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - How it works: how_it_works.md
   - Using HyP3:
-      - Vertex: https://search.asf.alaska.edu/#/?topic=onDemand" target="_blank
-      - SDK:
-        - using/sdk.md
-        - Example Notebook: https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb" target="_blank
-        - API Reference: using/sdk_api.md
-      - API: using/api.md
+    - Vertex: https://search.asf.alaska.edu/#/?topic=onDemand" target="_blank
+    - SDK:
+      - using/sdk.md
+      - Example Notebook: https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb" target="_blank
+      - API Reference: using/sdk_api.md
+    - API: using/api.md
+  - Introduction to SAR:
+    - guides/introduction_to_sar.md
+    - Digital Elevation Models: dems.md
   - Products:
-      - products.md
-      - Digital Elevation Models: dems.md
-      - Product guides:
-          - Introduction to SAR: guides/introduction_to_sar.md
-          - RTC Product Guide: guides/rtc_product_guide.md
-          - RTC ATBD: guides/rtc_atbd.md
-          - InSAR Product Guide: guides/insar_product_guide.md
-  - Other tools:
-      - ArcGIS Toolbox: tools/arcgis_toolbox.md
-      - ASF Tools for Python:
-        - tools/asf_tools.md
-        - API Reference: tools/asf_tools_api.md
-  - Plugins:
-      - plugins.md
-      # - HyP3 GAMMA: plugins/gamma.md
-      # - HyP3 autoRIFT: plugins/autoRIFT.md
-  - Contributing: contributing.md
-  - Code of Conduct: CODE_OF_CONDUCT.md
+    - products.md
+    - RTC:
+      - guides/rtc_product_guide.md
+      - Product Guide: guides/rtc_product_guide.md
+      - Story Map: https://storymaps.arcgis.com/stories/2ead3222d2294d1fae1d11d3f98d7c35" target="_blank
+      - Theoretical Basis: guides/rtc_atbd.md
+    - InSAR:
+      - guides/insar_product_guide.md
+      - Product Guide: guides/insar_product_guide.md
+      - Story Map: https://storymaps.arcgis.com/stories/68a8a3253900411185ae9eb6bb5283d3" target="_blank
+    - AutoRIFT: https://its-live.jpl.nasa.gov/" target="_blank
+    - Usage Guidelines: usage_guidelines.md
+  - Other Tools:
+    - ArcGIS Toolbox: tools/arcgis_toolbox.md
+    - ASF Tools for Python:
+      - tools/asf_tools.md
+      - API Reference: tools/asf_tools_api.md
+  - Developers:
+    - Architecture: how_it_works.md
+    - Plugins: plugins.md
+    - Contributing: contributing.md
+    - Code of Conduct: CODE_OF_CONDUCT.md
 
 plugins:
   - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
   - SAR Basics:
     - guides/introduction_to_sar.md
     - Introduction to SAR: guides/introduction_to_sar.md
+    - SAR FAQ: https://asf.alaska.edu/information/sar-information/what-is-sar/#sar_faq" target="_blank
     - Digital Elevation Models: dems.md
   - Other Tools:
     - ArcGIS Toolbox: tools/arcgis_toolbox.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,9 +38,6 @@ nav:
       - Example Notebook: https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb" target="_blank
       - API Reference: using/sdk_api.md
     - API: using/api.md
-  - Introduction to SAR:
-    - guides/introduction_to_sar.md
-    - Digital Elevation Models: dems.md
   - Products:
     - products.md
     - RTC:
@@ -54,6 +51,10 @@ nav:
       - Story Map: https://storymaps.arcgis.com/stories/68a8a3253900411185ae9eb6bb5283d3" target="_blank
     - AutoRIFT: https://its-live.jpl.nasa.gov/" target="_blank
     - Usage Guidelines: usage_guidelines.md
+  - SAR Basics:
+    - guides/introduction_to_sar.md
+    - Introduction to SAR: guides/introduction_to_sar.md
+    - Digital Elevation Models: dems.md
   - Other Tools:
     - ArcGIS Toolbox: tools/arcgis_toolbox.md
     - ASF Tools for Python:


### PR DESCRIPTION
Turns out this doesn't require implementing any redirects, since page URLs are ultimately based on the directory structure, not the table of contents.

That said, the directory structure in the repository doesn't particularly mimic the table of contents now.  It would be nice if the two were aligned, but I'm fine leaving things how they are for now, since moving/renaming files means implementing redirects.