### PR TITLE
Update autoRIFT anchor in link on DEM page

### DIFF
--- a/docs/dems.md
+++ b/docs/dems.md
@@ -66,6 +66,6 @@ Figure 3 shows the coverage of the various legacy DEM sources.
 
 ## Special Use DEMs
 
-[AutoRIFT](products.md#autorift-sdk-api-only){target=blank}, a process developed by the [NASA MEaSUREs ITS_LIVE](https://its-live.jpl.nasa.gov/){target=_blank}
+[AutoRIFT](products.md#autorift){target=blank}, a process developed by the [NASA MEaSUREs ITS_LIVE](https://its-live.jpl.nasa.gov/){target=_blank}
 project, processes use a custom Greenland and Antarctica DEM with a 240 m resolution. The DEM,
 associated process input files, and their details are available on the ITS_LIVE project website. 


### PR DESCRIPTION
We updated the product header for autoRIFT when it was included in vertex and dropped the API/SDK only bits. 

Found this by using https://validator.w3.org/checklink on our test site and it was the only link that needed to be changed. 