### PR TITLE
Water mask documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8](https://github.com/ASFHyP3/hyp3-docs/compare/v0.3.7...v0.3.8)
+
+### Changed
+* Updated the [InSAR Product Guide](docs/guides/insar_product_guide.md) to document the inclusion of a water mask in the InSAR product package
 
 ## [0.3.7](https://github.com/ASFHyP3/hyp3-docs/compare/v0.3.6...v0.3.7)
 

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -119,8 +119,6 @@ There are several options users can set when ordering InSAR On Demand products. 
 
 6. A copy of the **DEM** used for processing can optionally be included in the product package. The height values will differ from the original Copernicus DEM dataset, as a geoid correction has been applied, and it has been projected to UTM Zone coordinates. The source DEM is also downsampled to twice the pixel spacing of the output product to smooth it for use in processing, then resampled again to match the pixel spacing of the InSAR product. The DEM is excluded by default.
 
-7. *Under Development:* There is an option to apply a **water mask**. This mask generally only includes oceans and seas, though some large inland lakes are also masked. There is a buffer applied to the shoreline mask so that most of the waterbody is masked without inadvertently masking near-shore features. Masking waterbodies can have a significant impact during the phase unwrapping, as water can sometimes exhibit enough coherence between acquisitions to allow for unwrapping to occur over waterbodies, which is invalid. A GeoTIFF of the water mask is always included with the InSAR product package, but when this option is selected, the conditional water mask will be applied along with coherence and intensity thresholds during the phase unwrapping process. Water masking is turned off by default. 
-
 ## InSAR Workflow
 
 The InSAR workflow used in HyP3 was developed by ASF using GAMMA software.  The steps include pre-processing steps, interferogram preparation, and product creation.  Once these steps are performed, an output product package will be created.  See [product packaging](#product-packaging) for details on the individual files included in the package.  
@@ -216,7 +214,7 @@ The InSAR product names are packed with information pertaining to the processing
 - The product type (always INT for InSAR) and the pixel spacing, which will be either 80 or 40, based upon the number of looks selected when the job was submitted for processing
 - The software package used for processing is always GAMMA for GAMMA InSAR products
 - User-defined options are denoted by three characters indicating whether the product is water masked (w) or not (u), the scene is clipped (e for entire area, c for clipped), and whether a single sub-swath was processed or the entire granule (either 1, 2, 3, or F for full swath)
-    - *Currently only the water masking is available as a user-selected option; the products always include the full granule extent with all three sub-swaths*
+    - *Currently only the water masking will be made available as a user-selected option; the products always include the full granule extent with all three sub-swaths*
 - The filename ends with the ASF product ID, a 4 digit hexadecimal number
 
 
@@ -238,8 +236,6 @@ All of the main InSAR product files are 32-bit floating-point single-band GeoTIF
 - The *incidence angle* map gives the local incidence angle of the terrain. *(optional)*
 - The *DEM* file gives the local terrain heights in meters, with a geoid correction applied. *(optional)*
 - The *water mask* file indicates coastal waters beyond 3 km from the shoreline. Pixel values of 1 indicate land and 0 indicate water. This file is in 8-bit unsigned integer format.
-
-If the **water mask** option is selected, the water mask is applied prior to phase unwrapping to exclude water pixels from the process. The water mask is not precise; the coastal shorelines from the [GSHHG](http://www.soest.hawaii.edu/wessel/gshhg/land) are buffered out to 3 km from shore to reduce the possibility of near-shore features being excluded while reducing the number of water pixels that may impact the quality of the phase unwrapping process. Inland waters are not masked.
 
 **Browse images** are included for the wrapped (color_phase) and unwrapped (unw_phase) phase files, which are in PNG format and are each 2048 pixels wide. 
 

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -237,8 +237,9 @@ All of the main InSAR product files are 32-bit floating-point single-band GeoTIF
 - The *look vectors* &#966 and &#952 describe the elevation and orientation angles of the sensor's look direction. *(optional)*
 - The *incidence angle* map gives the local incidence angle of the terrain. *(optional)*
 - The *DEM* file gives the local terrain heights in meters, with a geoid correction applied. *(optional)*
+- The *water mask* file indicates coastal waters beyond 3 km from the shoreline. Pixel values of 1 indicate land and 0 indicate water. This file is in 8-bit unsigned integer format.
 
-If the **water mask** option is applied, a byte type GeoTIFF with pixel values of 0 for areas masked as water and 1 for unmasked areas is included in the package for reference. The water mask is not precise; land is buffered to reduce the possibility of near-shore features being excluded while reducing the impact of phase-unwrapping errors over large expanses of water.
+If the **water mask** option is selected, the water mask is applied prior to phase unwrapping to exclude water pixels from the process. The water mask is not precise; the coastal shorelines from the [GSHHG](http://www.soest.hawaii.edu/wessel/gshhg/land) are buffered out to 3 km from shore to reduce the possibility of near-shore features being excluded while reducing the number of water pixels that may impact the quality of the phase unwrapping process. Inland waters are not masked.
 
 **Browse images** are included for the wrapped (color_phase) and unwrapped (unw_phase) phase files, which are in PNG format and are each 2048 pixels wide. 
 

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -200,7 +200,7 @@ Geocoding is the process of reprojecting pixels from SAR slant range space (wher
 
 #### Product Creation
 
-Files are next exported from GAMMA internal format into the widely-used GeoTIFF format, complete with geolocation information. GeoTIFFs are created for amplitude, coherence, unwrapped phase, and vertical displacement by default. Optionally, GeoTIFFs of look vectors, line-of-sight displacement, incidence angle, and a water mask can also be requested.  
+Files are next exported from GAMMA internal format into the widely-used GeoTIFF format, complete with geolocation information. GeoTIFFs are created for amplitude, coherence, unwrapped phase, and vertical displacement by default, and a water mask GeoTIFF is also included in the product package. Optionally, GeoTIFFs of wrapped phase, look vectors, line-of-sight displacement and incidence angle can also be requested, as can a copy of the DEM used for processing.
  
 ## Product Packaging
 

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -105,7 +105,7 @@ To analyze deformation caused by a single discrete event, such as an earthquake,
 
     The option to apply the water mask to the InSAR product prior to phase unwrapping is currently under development. Stay tuned!
 
-There are several options users can set when ordering InSAR On Demand products.  Currently, users can choose the number of looks to take (which drives the resolution and pixel spacing of the products), whether to apply a water mask, and which optional products to include in the output package. The options are described below: 
+There are several options users can set when ordering InSAR On Demand products. Currently, users can choose the number of looks to take (which drives the resolution and pixel spacing of the products), and which optional products to include in the output package. The options are described below: 
 
 1. The **number of looks** drives the resolution and pixel spacing of the output products. Selecting 10x2 looks will yield larger products with 80 m resolution and pixel spacing of 40 m. Selecting 20x4 looks reduces the resolution to 160 m and reduces the size of the products (roughly 1/4 the size of 10x2 look products), with a pixel spacing of 80 m. The default is 20x4 looks.
 
@@ -117,9 +117,9 @@ There are several options users can set when ordering InSAR On Demand products. 
    
 5. The **local incidence angle** is defined as the angle between the incident radar signal and the local surface normal, expressed in radians. The default is to not include the incidence angle data file.
 
-6. There is an option to apply a **water mask**. This mask generally only includes oceans and seas, though some large inland lakes are also masked. There is a buffer applied to the shoreline mask so that most of the waterbody is masked without inadvertantly masking near-shore features. Masking waterbodies can have a significant impact during the phase unwrapping, as water can sometimes exhibit enough coherence between acquisitions to allow for unwrapping to occur over waterbodies, which is invalid. When this option is selected, a separate water mask GeoTIFF (indicating which pixels are masked) is also included in the product package. Water masking is turned off by default. 
+6. A copy of the **DEM** used for processing can optionally be included in the product package. The height values will differ from the original Copernicus DEM dataset, as a geoid correction has been applied, and it has been projected to UTM Zone coordinates. The source DEM is also downsampled to twice the pixel spacing of the output product to smooth it for use in processing, then resampled again to match the pixel spacing of the InSAR product. The DEM is excluded by default.
 
-7. A copy of the **DEM** used for processing can optionally be included in the product package. The height values will differ from the original Copernicus DEM dataset, as a geoid correction has been applied, and it has been projected to UTM Zone coordinates. The DEM is excluded by default.
+7. *Under Development:* There is an option to apply a **water mask**. This mask generally only includes oceans and seas, though some large inland lakes are also masked. There is a buffer applied to the shoreline mask so that most of the waterbody is masked without inadvertently masking near-shore features. Masking waterbodies can have a significant impact during the phase unwrapping, as water can sometimes exhibit enough coherence between acquisitions to allow for unwrapping to occur over waterbodies, which is invalid. A GeoTIFF of the water mask is always included with the InSAR product package, but when this option is selected, the conditional water mask will be applied along with coherence and intensity thresholds during the phase unwrapping process. Water masking is turned off by default. 
 
 ## InSAR Workflow
 

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -260,8 +260,8 @@ The tags and extensions used and example file names for each raster are listed i
 | _lv_phi.tif | Look vector &#966 | {{ base_name }}_lv_phi.tif |
 | _lv_theta.tif | Look vector &#952 | {{ base_name }}_lv_theta.tif |
 | _dem.tif | Digital elevation model | {{ base_name }}_dem.tif |
-| _mask.tif | Water mask | {{ base_name }}_mask.tif |
 | _inc_map.tif | Incidence angle | {{ base_name }}_inc_map.tif |
+| _water_mask.tif | Water mask | {{ base_name }}_water_mask.tif |
 | _color_phase.kmz | Wrapped phase kmz file | {{ base_name }}_color_phase.kmz |
 | _unw_phase.kmz | Unwrapped phase kmz file | {{ base_name }}_unw_phase.kmz |
 | _color_phase.png | Wrapped phase browse image | {{ base_name }}_color_phase.png |

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -99,11 +99,11 @@ To analyze deformation caused by a single discrete event, such as an earthquake,
 
 ### Processing Options 
 
-!!! important "New Options Available!" 
+!!! important "Water Mask GeoTIFF Now Included" 
 
-    Users can now include GeoTIFF outputs for the **wrapped phase**, the **local incidence angle**, and the **DEM** used for processing. This is in addition to the original options to set the resolution (number of looks), and whether to include the look vector maps and the line-of-sight displacement map.
+    A water mask GeoTIFF is now included with the InSAR product output. The mask uses the [GSHHG shoreline data](http://www.soest.hawaii.edu/wessel/gshhg/) with a 3-km buffer applied to reduce the chance that land may be excluded. Inland waters are not masked. Pixels over water have a value of 0, while pixels over land have a value of 1.
 
-    The water masking option is under development and will be available soon. 
+    The option to apply the water mask to the InSAR product prior to phase unwrapping is currently under development. Stay tuned!
 
 There are several options users can set when ordering InSAR On Demand products.  Currently, users can choose the number of looks to take (which drives the resolution and pixel spacing of the products), whether to apply a water mask, and which optional products to include in the output package. The options are described below: 
 


### PR DESCRIPTION
This PR adjusts the InSAR Product Guide to include documentation of the water mask GeoTIFF added to the product package.

References to the water mask being applied to the phase unwrapping process have been removed (in one commit) for the time being, and can be added back in once that option is ready for release. 
