### PR TITLE
Change water masking announcement to be sdk-specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.14](https://github.com/ASFHyP3/hyp3-docs/compare/v0.3.13...v0.3.14)
+
+### Changed
+* Clarified the availability of the 'apply water mask' option in the InSAR product guide
+
 ## [0.3.13](https://github.com/ASFHyP3/hyp3-docs/compare/v0.3.12...v0.3.13)
 
 ### Changed

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -101,7 +101,7 @@ To analyze deformation caused by a single discrete event, such as an earthquake,
 
 !!! important "New Water Masking Option Available!" 
 
-    InSAR products can now be phase unwrapped using a water mask. The option to "Apply water mask" sets pixels over coastal waters and large inland waterbodies as invalid for phase unwrapping. This reduces phase unwrapping errors and outputs a less noisy unwrapped interferogram.
+    InSAR products can now be phase unwrapped using a water mask. The option to "Apply water mask" sets pixels over coastal waters and large inland waterbodies as invalid for phase unwrapping. This reduces phase unwrapping errors and outputs a less noisy unwrapped interferogram. This option is currently only available in the SDK, but is coming soon in Vertex!
 
 There are several options users can set when ordering InSAR On Demand products. Currently, users can choose the number of looks to take (which drives the resolution and pixel spacing of the products), and which optional products to include in the output package. The options are described below: 
 

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -101,7 +101,7 @@ To analyze deformation caused by a single discrete event, such as an earthquake,
 
 !!! important "New Water Masking Option Available!" 
 
-    InSAR products can now be phase unwrapped using a water mask. The option to "Apply water mask" sets pixels over coastal waters and large inland waterbodies as invalid for phase unwrapping. This reduces phase unwrapping errors and outputs a less noisy unwrapped interferogram. This option is currently only available in the SDK, but is coming soon in Vertex!
+    InSAR products can now be phase unwrapped using a water mask. The option to "Apply water mask" sets pixels over coastal waters and large inland waterbodies as invalid for phase unwrapping. This reduces phase unwrapping errors and outputs a less noisy unwrapped interferogram. This option is currently available in the [API](https://hyp3-docs.asf.alaska.edu/using/api/) and [SDK](https://hyp3-docs.asf.alaska.edu/using/sdk/), and is coming soon in Vertex!
 
 There are several options users can set when ordering InSAR On Demand products. Currently, users can choose the number of looks to take (which drives the resolution and pixel spacing of the products), and which optional products to include in the output package. The options are described below: 
 


### PR DESCRIPTION
The message box announcing the availability of the water mask did not specify that it is currently only available in the SDK. 
Added clarifying language to the announcement. 

@jhkennedy or @asjohnston-asf Does this require a change in the patch number? Or can we release a bumpless change for this through to production? 