### PR TITLE
Correct figure attribution in InSAR product guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.22](https://github.com/ASFHyP3/hyp3-docs/compare/v0.3.20...v0.3.21)
+
+### Changed
+* Corrected figure attribution in [InSAR Product Guide](docs/guides/insar_product_guide.md)
 
 ## [0.3.21](https://github.com/ASFHyP3/hyp3-docs/compare/v0.3.20...v0.3.21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.3.22](https://github.com/ASFHyP3/hyp3-docs/compare/v0.3.20...v0.3.21)
 
 ### Changed
-* Corrected figure attribution in [InSAR Product Guide](docs/guides/insar_product_guide.md)
+* Corrected the attribution for Figure 1 in the [InSAR Product Guide](docs/guides/insar_product_guide.md)
 
 ## [0.3.21](https://github.com/ASFHyP3/hyp3-docs/compare/v0.3.20...v0.3.21)
 

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -17,7 +17,7 @@ SAR is an active sensor that transmits pulses and listens for echoes. These echo
 
 ![Figure 1](../images/phase_diff.png "Difference in range shows movement of the surface imaged")
 
-*Figure 1: Two passes of an imaging SAR taken at time T<sub>0</sub> and T<sub>0</sub> + ∆t, will give two distances to the ground, R<sub>1</sub> and R<sub>2</sub>.  A difference between R<sub>1</sub> and R<sub>2</sub> shows motion on the ground.  In this case, a subsidence makes R<sub>2</sub> greater than R<sub>1</sub>.  Credit: Franz J. Meyer*
+*Figure 1: Two passes of an imaging SAR taken at time T<sub>0</sub> and T<sub>0</sub> + ∆t, will give two distances to the ground, R<sub>1</sub> and R<sub>2</sub>.  A difference between R<sub>1</sub> and R<sub>2</sub> shows motion on the ground.  In this case, a subsidence makes R<sub>2</sub> greater than R<sub>1</sub>.  Credit: [TRE ALTAMIRA](https://site.tre-altamira.com/insar/)*
 
 InSAR exploits the phase difference between two SAR images to create an interferogram that shows where the phase and, therefore, the distance to the target has changed from one pass to the next, as illustrated in Figure 1.  There are several factors that influence the interferogram, including earth curvature, topographic effects, atmospheric delays, surface motion, and noise.  With proper processing, Sentinel-1 InSAR can be used to detect changes in the earth's surface down to the centimeter scale. Applications include volcanic deformation, subsidence, landslide detection, and earthquake assessment.
 


### PR DESCRIPTION
The figures in the InSAR product guide are incorrectly attributed. This PR corrects the first one. 