### PR TITLE
Update mkdocs dependency for jina2 bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.30]
+
+### Fixed
+* Update MkDocs to version >1.2.3 to fix a Jinja2 compatibility issue
+  (see [#197](https://github.com/ASFHyP3/hyp3-docs/pull/197))
+
 ## [0.3.29]
 
 ### Changed

--- a/environment.yml
+++ b/environment.yml
@@ -6,8 +6,7 @@ dependencies:
   - python=3.8
   - pip
   # For documentation
-  - jinja2<3.1  # FIXME: Hack until mkdocs >1.2.3 released
-  - mkdocs
+  - mkdocs>1.2.3
   - mkdocs-material=6.2
   - mkdocs-material-extensions
   - hyp3_sdk=1.4.1  # also pinned in docs/using/sdk.md


### PR DESCRIPTION
MkDocs versions <=1.2.3 rely on a depreciated Jina2 method that was removed in Jinja2 v3.1. MkDocs v1.2.4+ is fully compatible with Jina2 3.1 and maintains backwards compatibility with older Jinja2 versions. 

 The removed the temporary Jinja2 constraint and adds the correct MkDocs constraint.