### PR TITLE
Add tutorials landing page and easy MintPy tutorial link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.40]
+
+### Added
+* Added a quick link to our [MintPy tutorial notebook](https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-docs/blob/main/docs/tutorials/hyp3_insar_stack_for_ts_analysis.ipynb)
+* Added a Landing page for [HyP3 tutorials](docs/tutorials.md)
+
 ## [0.3.39]
 
 ### Added

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,5 +1,16 @@
 # HyP3 Tutorials
 
+## Jupyter Notebooks
+
+We provide step-by-step tutorials for using HyP3 programmatically via Jupyter Notebooks. 
+
+* [Using the HyP3 Python SDK](https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb "Using the HyP3 SDK Tutorial" ){target=blank}
+  -- This notebook walks through ordering and accessing RTC, InSAR, and autoRIFT products in Python using the HyP3 SDK.
+* [Time series analysis with HyP3 and MintPy](https://nbviewer.org/github/ASFHyP3/hyp3-docs/blob/main/docs/tutorials/hyp3_insar_stack_for_ts_analysis.ipynb "Time series analysis with HyP3 and MintPy Tutorial" ){target=blank}
+  -- This notebook walks through performing a time-series analysis of the 2019 
+  Ridgecrest, CA earthquake with HyP3 On Demand InSAR products and MintPy.
+
+
 ## Story maps
 
 We provide step-by-step tutorials for ordering and accessing
@@ -15,13 +26,3 @@ ASF also provides a variety of Esri Story Map tutorials and resources for using
 Synthetic Aperture Radar (SAR) data available from ASF. Check them all out here:
 
 * [Story Map Tutorials](https://asf-daac.maps.arcgis.com/home/index.html "Story Map Tutorials" ){target=blank}
-
-## Jupyter Notebooks
-
-We provide step-by-step tutorials for using HyP3 programmatically via Jupyter Notebooks. 
-
-* [Using the HyP3 Python SDK](https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb "Using the HyP3 SDK Tutorial" ){target=blank}
-  -- This notebook walks through ordering and accessing RTC, InSAR, and autoRIFT products in Python using the HyP3 SDK.
-* [Time series analysis with HyP3 and MintPy](https://nbviewer.org/github/ASFHyP3/hyp3-docs/blob/main/docs/tutorials/hyp3_insar_stack_for_ts_analysis.ipynb "Time series analysis with HyP3 and MintPy Tutorial" ){target=blank}
-  -- This notebook walks through performing a time-series analysis of the 2019 
-  Ridgecrest, CA earthquake with HyP3 On Demand InSAR products and MintPy.

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,0 +1,27 @@
+# HyP3 Tutorials
+
+## Story maps
+
+We provide step-by-step tutorials for ordering and accessing
+[RTC](https://storymaps.arcgis.com/stories/2ead3222d2294d1fae1d11d3f98d7c35 "RTC On Demand Story Map" ){target=blank}
+and [InSAR](https://storymaps.arcgis.com/stories/68a8a3253900411185ae9eb6bb5283d3 "InSAR On Demand Story Map" ){target=blank}
+products in Vertex.
+
+[![RTC On Demand Image](images/rtc-tutorial.png "Click to open RTC On Demand! tutorial")](https://storymaps.arcgis.com/stories/2ead3222d2294d1fae1d11d3f98d7c35 "RTC On Demand!" ){target=blank}
+[![InSAR On Demand Image](images/insar-tutorial.png "Click to open InSAR On Demand! tutorial")](https://storymaps.arcgis.com/stories/68a8a3253900411185ae9eb6bb5283d3 "InSAR On Demand!" ){target=blank}
+
+
+ASF also provides a variety of Esri Story Map tutorials and resources for using
+Synthetic Aperture Radar (SAR) data available from ASF. Check them all out here:
+
+* [Story Map Tutorials](https://asf-daac.maps.arcgis.com/home/index.html "Story Map Tutorials" ){target=blank}
+
+## Jupyter Notebooks
+
+We provide step-by-step tutorials for using HyP3 programmatically via Jupyter Notebooks. 
+
+* [Using the HyP3 Python SDK](https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-sdk/blob/main/docs/sdk_example.ipynb "Using the HyP3 SDK Tutorial" ){target=blank}
+  -- This notebook walks through ordering and accessing RTC, InSAR, and autoRIFT products in Python using the HyP3 SDK.
+* [Time series analysis with HyP3 and MintPy](https://nbviewer.org/github/ASFHyP3/hyp3-docs/blob/main/docs/tutorials/hyp3_insar_stack_for_ts_analysis.ipynb "Time series analysis with HyP3 and MintPy Tutorial" ){target=blank}
+  -- This notebook walks through performing a time-series analysis of the 2019 
+  Ridgecrest, CA earthquake with HyP3 On Demand InSAR products and MintPy.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
     - Digital Elevation Models: dems.md
     - SAR FAQ: https://asf.alaska.edu/information/sar-information/what-is-sar/#sar_faq" target="_blank
   - Tutorials:
+    - tutorials.md
     - InSAR time series with MintPy: https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-docs/blob/main/docs/tutorials/hyp3_insar_stack_for_ts_analysis.ipynb" target="_blank
     - Story Map Tutorials: https://asf-daac.maps.arcgis.com/home/index.html" target="_blank
   - Other Tools:
@@ -91,3 +92,4 @@ plugins:
         # full link to our hosted docs needed b/c mkdocs-redirects doesn't support hash fragments
         #    See: https://github.com/datarobot/mkdocs-redirects/issues/16
         getting_started.md: 'https://hyp3-docs.asf.alaska.edu/#getting-started'
+        tutorials/mintpy.md: 'https://nbviewer.jupyter.org/github/ASFHyP3/hyp3-docs/blob/main/docs/tutorials/hyp3_insar_stack_for_ts_analysis.ipynb'


### PR DESCRIPTION
The landing page is needed to easily link to our tutorials on the hyp3-docs site. I also added a super quick link to the MintPy tutorial, which I've suggested we use in  ASFHyP3/hyp3-lib#264