### PR TITLE
fix broken 'get started' link in rtc product guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.48]
+
+### Fixed
+* Corrected broken "Get Started" link in the RTC Product Guide.
+
 ## [0.3.47]
 
 ### Changed

--- a/docs/guides/rtc_product_guide.md
+++ b/docs/guides/rtc_product_guide.md
@@ -357,6 +357,6 @@ To view or download Sentinel-1 RTC products, please see the links below:
 
 **API:** [https://asf.alaska.edu/api/](https://asf.alaska.edu/api/ "https://asf.alaska.edu/api" ){target=_blank}
 
-For details on accessing data, including other SAR datasets, see ASF’s Get Started guide: [https://asf.alaska.edu/how-to/get-started/](https://asf.alaska.edu/how-to/get-started/ "https://asf.alaska.edu/how-to/get-started" ){target=_blank}
+For details on accessing data, including other SAR datasets, see ASF’s Get Started guide: [https://asf.alaska.edu/getstarted/](https://asf.alaska.edu/getstarted/ "https://asf.alaska.edu/getstarted/" ){target=_blank}
 
 To access data recipes, which are step-by-step tutorials for processing and working with SAR data, see ASF’s tutorials page: [https://asf.alaska.edu/how-to/data-recipes/data-recipe-tutorials/](https://asf.alaska.edu/how-to/data-recipes/data-recipe-tutorials/ "https://asf.alaska.edu/how-to/data-recipes/data-recipe-tutorials" ){target=_blank}


### PR DESCRIPTION
I've confirmed this link doesn't appear anywhere besides the RTC product guide.