### PR TITLE
Add pixel spacing information to RTC Product Guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.56]
+
+## Added
+* Section about RTC pixel spacing added to the [RTC Product Guide](docs/guides/rtc_product_guide.md)
 
 ## [0.3.55]
 

--- a/docs/guides/rtc_product_guide.md
+++ b/docs/guides/rtc_product_guide.md
@@ -171,6 +171,7 @@ The default settings for RTC products are as follows:
 
 | Setting | Default |
 |---|---|
+| Pixel Spacing | 30 |
 | Radiometry | Gamma-0 (g) |
 | Scale | Power (p) |
 | Water Mask | No water mask applied (u) |

--- a/docs/guides/rtc_product_guide.md
+++ b/docs/guides/rtc_product_guide.md
@@ -105,7 +105,7 @@ Figure 4 shows the coverage of the various legacy DEM sources.
 
 RTC products can be output either at 30-meter or 10-meter pixel spacing. In most cases, the input SAR image has a higher resolution than either of the RTC outputs. The 10-m RTC product will be closer to the resolution of the source SAR granule, but the 30-m RTC product has a much smaller file size. 
 
-It is *much* faster to process and analyze 30-m products, so it's a good idea to start with the coarser resolution option if possible. If the 30-m pixel spacing is not sufficient for your use case, try the larger 10-m products. 
+It is *much* faster to process and analyze 30-m RTC products, so it's a good idea to start with the coarser resolution option if possible. If the 30-m pixel spacing is not sufficient for your use case, try the larger 10-m RTC products. 
 
 Keep in mind that the same DEM is used for processing both the 10-m and 30-m RTC products. By default, the DEM is the Copernicus Global DEM with a pixel spacing of 30 meters. The DEM is resampled to a pixel spacing of 10 meters when used for processing the 10-m RTC products, and the output DEM included in the 10-m RTC product package has a pixel spacing of 10 meters to match the output RTC product. *This does not indicate that the source DEM used for the 10-m products is of higher resolution.*
 

--- a/docs/guides/rtc_product_guide.md
+++ b/docs/guides/rtc_product_guide.md
@@ -101,6 +101,14 @@ Figure 4 shows the coverage of the various legacy DEM sources.
 
 *Figure 4: Coverage of the various legacy DEM sources used for terrain correction*
 
+## Pixel Spacing
+
+RTC products can be output either at 30-meter or 10-meter pixel spacing. In most cases, the input SAR image has a higher resolution than the RTC output, but the 10-m RTC product will be closer to the resolution of the source SAR granule. 
+
+Keep in mind that the same DEM is used for processing both the 10-m and 30-m RTC products. By default, the DEM is the Copernicus Global DEM with a pixel spacing of 30 meters. The DEM is resampled to 10-m pixel spacing when used for processing the 10-m RTC products, and the output DEM included in the RTC product package has a pixel spacing of 10 meters to match the output RTC product. *This does not indicate that the source DEM used for the 10-m products is of higher resolution.* 
+
+Be aware that the 10-m RTC products have a **much** larger file size than the 30-m RTC products. The default option for pixel spacing is 30 meters, which is generally suitable for monitoring landscape-level processes, especially when working with long time series. Even the 30-m products are quite sizeable, so it's a good idea to start with a 30-m product to see if it's sufficient for your use case. If the 30-m pixel spacing is too coarse, try using the 10-m option.
+
 ## Radiometric Terrain Correction Workflow
 
 ### Pre-processing

--- a/docs/guides/rtc_product_guide.md
+++ b/docs/guides/rtc_product_guide.md
@@ -107,7 +107,7 @@ RTC products can be output either at 30-meter or 10-meter pixel spacing. In most
 
 It is *much* faster to process and analyze 30-m products, so it's a good idea to start with the coarser resolution option if possible. If the 30-m pixel spacing is not sufficient for your use case, try the larger 10-m products. 
 
-Keep in mind that the same DEM is used for processing both the 10-m and 30-m RTC products. By default, the DEM is the Copernicus Global DEM with a pixel spacing of 30 meters. The DEM is resampled to 10-m pixel spacing when used for processing the 10-m RTC products, and the output DEM included in the RTC product package has a pixel spacing of 10 meters to match the output RTC product. *This does not indicate that the source DEM used for the 10-m products is of higher resolution.*
+Keep in mind that the same DEM is used for processing both the 10-m and 30-m RTC products. By default, the DEM is the Copernicus Global DEM with a pixel spacing of 30 meters. The DEM is resampled to a pixel spacing of 10 meters when used for processing the 10-m RTC products, and the output DEM included in the 10-m RTC product package has a pixel spacing of 10 meters to match the output RTC product. *This does not indicate that the source DEM used for the 10-m products is of higher resolution.*
 
 ## Radiometric Terrain Correction Workflow
 

--- a/docs/guides/rtc_product_guide.md
+++ b/docs/guides/rtc_product_guide.md
@@ -103,11 +103,11 @@ Figure 4 shows the coverage of the various legacy DEM sources.
 
 ## Pixel Spacing
 
-RTC products can be output either at 30-meter or 10-meter pixel spacing. In most cases, the input SAR image has a higher resolution than the RTC output, but the 10-m RTC product will be closer to the resolution of the source SAR granule. 
+RTC products can be output either at 30-meter or 10-meter pixel spacing. In most cases, the input SAR image has a higher resolution than either of the RTC outputs. The 10-m RTC product will be closer to the resolution of the source SAR granule, but the 30-m RTC product has a much smaller file size. 
 
-Keep in mind that the same DEM is used for processing both the 10-m and 30-m RTC products. By default, the DEM is the Copernicus Global DEM with a pixel spacing of 30 meters. The DEM is resampled to 10-m pixel spacing when used for processing the 10-m RTC products, and the output DEM included in the RTC product package has a pixel spacing of 10 meters to match the output RTC product. *This does not indicate that the source DEM used for the 10-m products is of higher resolution.* 
+It is *much* faster to process and analyze 30-m products, so it's a good idea to start with the coarser resolution option if possible. If the 30-m pixel spacing is not sufficient for your use case, try the larger 10-m products. 
 
-Be aware that the 10-m RTC products have a **much** larger file size than the 30-m RTC products. The default option for pixel spacing is 30 meters, which is generally suitable for monitoring landscape-level processes, especially when working with long time series. Even the 30-m products are quite sizeable, so it's a good idea to start with a 30-m product to see if it's sufficient for your use case. If the 30-m pixel spacing is too coarse, try using the 10-m option.
+Keep in mind that the same DEM is used for processing both the 10-m and 30-m RTC products. By default, the DEM is the Copernicus Global DEM with a pixel spacing of 30 meters. The DEM is resampled to 10-m pixel spacing when used for processing the 10-m RTC products, and the output DEM included in the RTC product package has a pixel spacing of 10 meters to match the output RTC product. *This does not indicate that the source DEM used for the 10-m products is of higher resolution.*
 
 ## Radiometric Terrain Correction Workflow
 


### PR DESCRIPTION
This PR adds a section on RTC pixel spacing options to the Product Guide. It also adds pixel spacing to the default settings table.