### PR TITLE
remove navigation.instant to fix nasa tophat

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ theme:
   icon:
     repo: fontawesome/brands/github-alt
   features:
-    - navigation.instant
+    # - navigation.instant  # This doesn't work with the NASA Earthdata tophat; see ASFHyP3/hyp3-docs#371
     - navigation.footer
 
 repo_url: https://github.com/ASFHyP3


### PR DESCRIPTION
The NASA Earthdata tophat (black bar at top :point_down:) pulls in css/java on page refresh
![image](https://github.com/ASFHyP3/hyp3-docs/assets/7882693/a6d95fa4-9184-4ea3-8bf3-be13ae3ba65e)


When using `navigation.instant`, internal pages don't refresh so it acts/performs like a "single page" site, but this prevents the tophat css/java from working, leading to a top hat that looks like:
![image](https://github.com/ASFHyP3/hyp3-docs/assets/7882693/23f0c4da-402c-49fb-a793-7f121c34cda9)

Dropping `navigation.instant` fixes the issue. I've left it commented in the code pointing back to this issue to prevent us from enabling it again.