### PR TITLE
Setup analyics in site since it's no longer supported in the asf-mkdocs-theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 * Upgraded to `mkdocs-asf-theme==0.3.0`.
+* Google Analytics is set up directly in [mkdocs.yml](mkdocs.yml) as it's no longer set by default in the theme.
 
 ## [0.5.4]
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,11 @@ site_url: https://hyp3-docs.asf.alaska.edu/
 site_author: ASF APD/Tools Team
 site_description: The Alaska Satellite Facility's Hybrid Pluggable Processing Pipeline
 
+# ASF's Google Analytics
+google_analytics:
+  - UA-991100-5
+  - search.asf.alaska.edu
+
 theme:
   name: asf-theme
   logo: images/HyP3-graphic-only.png


### PR DESCRIPTION
Google Analytics 360 is no longer set by default in `mkdocs-asf-theme` as mkdocs and mkdocs-material only support Google Analytics 4 now, so this sets it up directly here.

Follow on work is captured in #372 