### PR TITLE
Add message about connected components file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - The [`update_asf_tools_version`](.github/workflows/update_asf_tools_version.yml) and [`update_sdk_version`](.github/workflows/update_sdk_version.yml) GitHub Actions workflows now use the `gh` CLI instead of the archived `repo-sync/pull-request` action.
 
+## [0.9.10]
+
+### Changed
+* Added information about connected components files to [InSAR Product Guide](https://hyp3-docs.asf.alaska.edu/guides/insar_product_guide.md)
+
 ## [0.9.9]
 
 ### Changed

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -167,6 +167,8 @@ All of the phase differences in wrapped interferograms lie between -π and π. P
 
 The phase unwrapping algorithm used for these products is Minimum Cost Flow (MCF) and Triangulation. Refer to this [Technical Report from GAMMA Remote Sensing](https://www.gamma-rs.ch/uploads/media/2002-5_TR_Phase_Unwrapping.pdf "https://www.gamma-rs.ch/uploads/media/2002-5_TR_Phase_Unwrapping.pdf" ){target=_blank} for more information on the MCF phase unwrapping approach.
 
+Note that the MCF algorithm does not generate a connected components file. If you require this file, consider using ASF's [Burst InSAR On Demand](insar_product_guide.md) option, which includes a connected components file in each output product package.
+
 #### Filtering
 Before the interferogram can be unwrapped, it must be filtered to remove noise. This is accomplished using an adaptive spectral filtering algorithm. This adaptive interferogram filtering aims to reduce phase noise, increase the accuracy of the interferometric phase, and reduce the number of interferogram residues as an aid to phase unwrapping. In this case, residues are points in the interferogram where the sum of the phase differences between pixels around a closed path is not 0.0, which indicates a jump in phase.
 

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -191,6 +191,9 @@ By default, ASF's On Demand InSAR products use the location of the pixel with th
 
 This may be an appropriate reference point location in many cases, as it meets the criteria of having high coherence, and stable areas have higher coherence than areas undergoing significant deformation. If a user wants to set a different location as the phase unwrapping reference point, however, a correction can be applied to the unwrapped interferogram.
 
+The location of the reference point is included in the product readme file, as well as the parameter metadata text file, 
+both of which are included in the product package by default.
+
 For more information on the impact of the phase unwrapping reference point location on unwrapped phase and displacement measurements, refer to the [Limitations](#phase-unwrapping-reference-point "Jump to Phase Unwrapping Reference Point part of the Limitations section in this document") section of this document, which also includes instructions for applying a correction based on a custom reference point. 
 
 ### Geocoding and Product Creation

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -30,6 +30,21 @@ There are several options users can set when ordering InSAR On Demand products, 
 
     There is now an option to adjust the adaptive phase filter parameter value when submitting On Demand InSAR jobs. This option is available in [Vertex](https://search.asf.alaska.edu/ "https://search.asf.alaska.edu/" ){target=_blank}, as well as in the [HyP3 API](../using/api.md ){target=_blank} and [Python SDK](../using/sdk.md ){target=_blank}! Refer to the [Adaptive Phase Filter section](#adaptive-phase-filter) for more information.
 
+!!! warning "Connected Components file not available for GAMMA-generated InSAR products from ASF" 
+
+    ASF uses GAMMA software to generate full-scene Sentinel-1 InSAR products. This workflow does not generate a 
+    connected components file, such as what is generated when using SNAPHU for phase unwrapping.
+
+    The location of the reference point is included in the product readme file, as well as the parameter metadata 
+    text file, both of which are included in the product package by default. Refer to the 
+    [Reference Point](#reference-point "Jump to Reference Point section of this document") section of this document 
+    for more information.
+
+    If you require connected components files for your analysis, consider using 
+    ASF's [Burst InSAR On Demand](burst_insar_product_guide.md) option, which uses
+    the ISCE2 software package to process individual Sentinel-1 SLC bursts to InSAR products. This workflow includes
+    a connected components file in the output product package.
+
 #### Processing Options
 
 When submitting jobs for processing, there are a number of parameters that can be set by the user.

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -28,23 +28,23 @@ There are several options users can set when ordering InSAR On Demand products, 
 
 !!! tip "New: Adaptive Phase Filter parameter is now customizable!"
 
-    There is now an option to adjust the adaptive phase filter parameter value when submitting On Demand InSAR jobs. This option is available in [Vertex](https://search.asf.alaska.edu/ "https://search.asf.alaska.edu/" ){target=_blank}, as well as in the [HyP3 API](../using/api.md ){target=_blank} and [Python SDK](../using/sdk.md ){target=_blank}! Refer to the [Adaptive Phase Filter section](#adaptive-phase-filter) for more information.
+    There is now an option to adjust the adaptive phase filter parameter value when submitting On Demand InSAR jobs.
+    This option is available in 
+    [Vertex](https://search.asf.alaska.edu/ "https://search.asf.alaska.edu/" ){target=_blank}, 
+    as well as in the [HyP3 API](../using/api.md ){target=_blank} and [Python SDK](../using/sdk.md ){target=_blank}! 
+    Refer to the [Adaptive Phase Filter section](#adaptive-phase-filter) for more information.
 
 !!! warning "Connected Components file not available for GAMMA-generated InSAR products from ASF" 
 
-    ASF uses GAMMA software's Minimum Cost Flow (MCF) algorithm to phase unwrap full-scene Sentinel-1 
-    InSAR products. This workflow does not generate a connected components file, such as what is generated 
-    when using SNAPHU for phase unwrapping.
+    ASF uses GAMMA software's [Minimum Cost Flow (MCF) algorithm](#phase-unwrapping) to phase unwrap full-scene 
+    Sentinel-1 InSAR products. This workflow does not generate a connected components file, such as what is generated 
+    when using [SNAPHU](https://web.stanford.edu/group/radar/softwareandlinks/sw/snaphu/ 
+    "https://web.stanford.edu/group/radar/softwareandlinks/sw/snaphu/" ){target=_blank} for phase unwrapping.
 
-    The location of the reference point is included in the product readme file, as well as the parameter metadata 
-    text file, both of which are included in the product package by default. Refer to the 
-    [Reference Point](#reference-point "Jump to Reference Point section of this document") section of this document 
-    for more information.
-
-    If you require connected components files for your analysis, consider using 
-    ASF's [Burst InSAR On Demand](burst_insar_product_guide.md) option, which uses
-    the ISCE2 software package to process individual Sentinel-1 SLC bursts to InSAR products. This workflow includes
-    a connected components file in the output product package.
+    If you require connected components files for your analysis, consider using ASF's 
+    [Burst InSAR On Demand](burst_insar_product_guide.md) option, which uses the ISCE2 software package 
+    to process individual Sentinel-1 SLC bursts to InSAR products. The 
+    [Burst InSAR product package](burst_insar_product_guide.md#image-files) contains a connected components file.
 
 #### Processing Options
 

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -32,8 +32,9 @@ There are several options users can set when ordering InSAR On Demand products, 
 
 !!! warning "Connected Components file not available for GAMMA-generated InSAR products from ASF" 
 
-    ASF uses GAMMA software to generate full-scene Sentinel-1 InSAR products. This workflow does not generate a 
-    connected components file, such as what is generated when using SNAPHU for phase unwrapping.
+    ASF uses GAMMA software's Minimum Cost Flow (MCF) algorithm to phase unwrap full-scene Sentinel-1 
+    InSAR products. This workflow does not generate a connected components file, such as what is generated 
+    when using SNAPHU for phase unwrapping.
 
     The location of the reference point is included in the product readme file, as well as the parameter metadata 
     text file, both of which are included in the product package by default. Refer to the 


### PR DESCRIPTION
This PR adds a warning box to the InSAR Product Guide alerting users to the fact that connected components files are not generated when using the GAMMA MCF algorithm for phase unwrapping. Related information is added in a couple of other relevant locations in the product guide.