### PR TITLE
Remove warning message about ARIA GUNW On Demand availability over Alaska

### DIFF
--- a/.github/dictionary.txt
+++ b/.github/dictionary.txt
@@ -179,6 +179,7 @@ Goldstein
 Goldstein-Werner
 Grayscale
 grayscale
+GRD
 GRD-H
 grey
 Gruber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.8]
+
+### Changed
+* Removed warning that ARIA GUNW products could not be processed On Demand over Alaska
+
 ## [0.10.7]
 
 ### Changed

--- a/docs/guides/gunw_product_guide.md
+++ b/docs/guides/gunw_product_guide.md
@@ -16,11 +16,6 @@ The ARIA project also maintains the [ARIA-tools](https://doi.org/10.1029/2020GL0
 
 While there is a large archive of ARIA-S1-GUNW products that have already been generated and are [ready for download](#accessing-existing-products "Jump to Accessing Existing Products section of this document"), they may not cover your area of interest. In addition, the archived products may not include the full range of temporal baseline pairings required for your analysis. If you are interested in ARIA-S1-GUNW products that are not already represented in the archive, ASF provides the ability to [generate these products using specific Sentinel-1 SLC pairings](#ordering-on-demand-products "Jump to Ordering On Demand Products section of this document"). 
 
-!!! warning "ARIA-S1-GUNW On-Demand processing not supported for Alaska"
-
-    ARIA-S1-GUNW products rely on RAiDER software for atmospheric delay correction. This software does not currently 
-    support processing acquisitions over Alaska, causing On-Demand ARIA-S1-GUNW jobs submitted over Alaska to fail. 
-
 The On Demand ARIA-S1-GUNW products are generated using the same code that is used to generate the archived products, so they are fully interoperable.
 
 ## Accessing Existing Products

--- a/docs/products.md
+++ b/docs/products.md
@@ -1,10 +1,15 @@
 # Available HyP3 Products
 
-On-demand SAR products generated using HyP3 are currently available for the [Sentinel-1 mission](sentinel1.md "Sentinel-1 Mission" ){target=_blank} only. Unless otherwise noted, 
-on-demand products are available for 14 days after they have been processed.
+On-demand SAR products generated using HyP3 are currently available for the 
+[Sentinel-1 mission](sentinel1.md "Sentinel-1 Mission") 
+only. Unless otherwise noted, On-Demand products are available for 14 days after they have been processed.
 
-A Digital Elevation Model (DEM) is required to generate each of the On-Demand products offered by ASF, and we generally use the [GLO-30 Copernicus DEM](https://dataspace.copernicus.eu/explore-data/data-collections/copernicus-contributing-missions/collections-description/COP-DEM "Copernicus DEM" ){target=_blank} in our processing workflows. 
-For more information, refer to our [Digital Elevation Models](dems.md "HyP3 DEM Documentation" ){target=_blank} documentation.
+A Digital Elevation Model (DEM) is required to generate each of the On-Demand products offered by ASF, and we 
+generally use the 
+[GLO-30 Copernicus DEM](https://dataspace.copernicus.eu/explore-data/data-collections/copernicus-contributing-missions/collections-description/COP-DEM "Copernicus DEM" ){target=_blank} 
+in our processing workflows. For more information, refer to our 
+[Digital Elevation Models](dems.md "HyP3 DEM Documentation") 
+documentation.
 
 ## RTC
 
@@ -13,11 +18,22 @@ being imaged by a side-looking instrument. Radiometric Terrain Correction (RTC) 
 these distortions and creates analysis-ready data suitable for use in GIS applications.
 RTC processing is a required first step for many amplitude-based SAR applications.
 
-Sentinel-1 RTC products are generated leveraging [GAMMA Software](https://gamma-rs.ch/gamma-software){target=_blank}. Products are distributed as UTM-projected GeoTIFFs 
-with a pixel spacing of [10, 20, or 30 meters](guides/rtc_product_guide.md#pixel-spacing "RTC Pixel Spacing Documentation" ){target=_blank}. To learn more, refer to the [Sentinel-1 RTC Product Guide](guides/rtc_product_guide.md 
-"Sentinel-1 RTC Product Guide" ){target=_blank}.
+Sentinel-1 RTC products are generated from Level-1 Sentinel-1 IW acquisitions (either GRD or SLC files), leveraging 
+[GAMMA Software](https://gamma-rs.ch/gamma-software){target=_blank}. 
+Products are distributed as GeoTIFFs projected to a UTM Zone, with a pixel spacing of 
+[10, 20, or 30 meters](guides/rtc_product_guide.md#pixel-spacing "RTC Pixel Spacing Documentation"). 
+Users can choose to output the products in 
+[gamma-0 or sigma-0 radiometry](guides/rtc_product_guide.md#radiometry "RTC Radiometry Documentation"), 
+and in 
+[power, amplitude, or dB scale](guides/rtc_product_guide.md#scale "RTC Scale Documentation"). 
+Users also have the option to 
+[apply a speckle filter](guides/rtc_product_guide.md#speckle-filter "RTC Speckle Filter Documentation"). 
+To learn more, refer to the [Sentinel-1 RTC Product Guide](guides/rtc_product_guide.md 
+"Sentinel-1 RTC Product Guide").
 
-For step-by-step instructions on searching for, ordering, downloading and using On Demand RTC products, visit our [RTC On Demand!](https://storymaps.arcgis.com/stories/2ead3222d2294d1fae1d11d3f98d7c35 "RTC On Demand! StoryMap" ){target=_blank} tutorial.
+For step-by-step instructions on searching for, ordering, downloading and using On-Demand RTC products, visit our 
+[RTC On Demand!](https://storymaps.arcgis.com/stories/2ead3222d2294d1fae1d11d3f98d7c35 "RTC On Demand! StoryMap" ){target=_blank} 
+tutorial.
 
 ## InSAR
 
@@ -28,47 +44,67 @@ deformation or ground movement.
 
 There are three different processing approaches available for generating On-Demand InSAR products from Sentinel-1: 
 
-  - Full-scene processing using GAMMA software 
-  - Burst-based processing using ISCE2 software
-  - ARIA Frame-based processing using ISCE2 software
+  - [Full-scene processing using GAMMA software](#full-scene-insar-gamma) 
+  - [Burst-based processing using ISCE2 software](#burst-based-insar-isce2)
+  - [ARIA Frame-based processing using ISCE2 software](#aria-sentinel-1-gunw-products-isce2)
 
 ### Full-scene InSAR (GAMMA)
 
-These products take Sentinel-1 IW SLC scene pairs as input, and processing is performed 
-using [GAMMA Software](https://gamma-rs.ch/gamma-software){target=_blank}. Products are 
-packaged as a collection of GeoTIFFs in a zip file. They are projected to the appropriate 
-UTM Zone for the product location, and can be generated at a pixel spacing of either 80 or 40 meters. To learn more, refer to the [Sentinel-1 InSAR Product Guide](guides/insar_product_guide.md "Sentinel-1 InSAR Product Guide").
+These products take Sentinel-1 IW SLC scene pairs as input, and processing is performed using 
+[GAMMA Software](https://gamma-rs.ch/gamma-software){target=_blank}. 
+Products are packaged as a collection of GeoTIFFs in a zip file. They are projected to the appropriate UTM Zone for 
+the product location and can be generated at a pixel spacing of either 80 or 40 meters. To learn more, refer to the 
+[Sentinel-1 InSAR Product Guide](guides/insar_product_guide.md "Sentinel-1 InSAR Product Guide").
 
 For step-by-step instructions on searching for, ordering and downloading On Demand InSAR products, visit our [InSAR On Demand!](https://storymaps.arcgis.com/stories/68a8a3253900411185ae9eb6bb5283d3 "InSAR On Demand! StoryMap" ){target=_blank} tutorial.
 
 ### Burst-based InSAR (ISCE2)
 
-These products take sets of individual [SLC bursts](https://storymaps.arcgis.com/stories/88c8fe67933340779eddef212d76b8b8 "Sentinel-1 Bursts StoryMap" ){target=_blank} 
+These products take sets of individual 
+[SLC bursts](https://storymaps.arcgis.com/stories/88c8fe67933340779eddef212d76b8b8 "Sentinel-1 Bursts StoryMap" ){target=_blank} 
 extracted from Sentinel-1 IW SLC products as input, and processing is performed using 
 [ISCE2 software](https://github.com/isce-framework/isce2#readme "https://github.com/isce-framework/isce2" ){target=_blank}. Products are packaged as a collection of 
 GeoTIFFs in a zip file. They are projected to the appropriate UTM Zone for the product 
 location, and can be generated at a pixel spacing of 80, 40, or 20 meters. 
 
-The advantage of using burst-based processing is that users have more control of the extent of the output interferogram, and the burst footprints always fully overlap from one acquisition to the next. Users can select sets of up to 15 contiguous along-track bursts to generate a single output interferogram. Refer to the [Sentinel-1 Burst InSAR Product Guide](guides/burst_insar_product_guide.md "Sentinel-1 Burst InSAR Product Guide") for more information.
+The advantage of using burst-based processing is that users have more control of the extent of the output 
+interferogram, and the burst footprints always fully overlap from one acquisition to the next. Users can select 
+sets of up to 15 contiguous along-track bursts to generate a single output interferogram. Refer to the 
+[Sentinel-1 Burst InSAR Product Guide](guides/burst_insar_product_guide.md "Sentinel-1 Burst InSAR Product Guide") 
+for more information.
 
-For step-by-step instructions on searching for, ordering and downloading On Demand Burst InSAR products, visit our [Burst-Based InSAR for Sentinel-1 On Demand](https://storymaps.arcgis.com/stories/191bf1b6962c402086807390b3ce63b0 "Burst-Based InSAR for Sentinel-1 On Demand StoryMap" ){target=_blank} tutorial.
+For step-by-step instructions on searching for, ordering and downloading On Demand Burst InSAR products, visit our 
+[Burst-Based InSAR for Sentinel-1 On Demand](https://storymaps.arcgis.com/stories/191bf1b6962c402086807390b3ce63b0 "Burst-Based InSAR for Sentinel-1 On Demand StoryMap" ){target=_blank} 
+tutorial.
 
 ### ARIA Sentinel-1 GUNW Products (ISCE2)
 
-There is an extensive archive of [ARIA S1 GUNW](https://aria.jpl.nasa.gov/products/standard-displacement-products.html "https://aria.jpl.nasa.gov" ){target=_blank} (Geocoded Unwrapped Interferogram) products [available from ASF](https://search.asf.alaska.edu/#/?maxResults=1000&dataset=SENTINEL-1%20INTERFEROGRAM%20(BETA) "Vertex search for ARIA S1 GUNW" ){target=_blank}, 
-but they are only generated in specific geographic locations. If the existing archive does 
-not provide the products you need, you can generate ARIA GUNW products on demand. 
+There is an extensive archive of 
+[ARIA S1 GUNW](https://aria.jpl.nasa.gov/products/standard-displacement-products.html "https://aria.jpl.nasa.gov" ){target=_blank} 
+(Geocoded Unwrapped Interferogram) products 
+[available from ASF](https://search.asf.alaska.edu/#/?maxResults=1000&dataset=SENTINEL-1%20INTERFEROGRAM%20(BETA) "Vertex search for ARIA S1 GUNW" ){target=_blank}, 
+but they are only generated in specific geographic locations. If the existing archive does not provide the 
+products you need, you can generate ARIA GUNW products on demand. 
 
 ARIA S1 GUNW products are delivered as netCDF files with 90-m pixel spacing. The On-Demand 
-products are generated using the same [ISCE2](https://github.com/isce-framework/isce2#readme "https://github.com/isce-framework/isce2" ){target=_blank}-based code used to generate the archived products, and standard ARIA S1 GUNW products 
-generated on demand are automatically added to the archive. This allows all users to access the on-demand products indefinitely, which is an exception to the 14-day availability period that applies to all other on-demand products.
+products are generated using the same 
+[ISCE2](https://github.com/isce-framework/isce2#readme "https://github.com/isce-framework/isce2" ){target=_blank}-based 
+code used to generate the archived products, and standard ARIA S1 GUNW products 
+generated on demand are automatically added to the archive. This allows all users to access the On-Demand products 
+indefinitely, which is an exception to the 14-day availability period that applies to all other On-Demand products.
 
-The ARIA S1 GUNW products use a set [framing system](guides/gunw_product_guide.md#aria-frame-ids "ARIA Sentinel-1 GUNW Product Guide: ARIA Frame IDs") to select consistent bursts from input Sentinel-1 IW SLCs to generate interferograms. Refer to the [ARIA Sentinel-1 GUNW Product Guide](guides/gunw_product_guide.md "ARIA Sentinel-1 GUNW Product Guide") for more information.
+The ARIA S1 GUNW products use a set [framing system](guides/gunw_product_guide.md#aria-frame-ids "ARIA Sentinel-1 GUNW 
+Product Guide: ARIA Frame IDs") to select consistent bursts from input Sentinel-1 IW SLCs to generate interferograms. 
+Refer to the 
+[ARIA Sentinel-1 GUNW Product Guide](guides/gunw_product_guide.md "ARIA Sentinel-1 GUNW Product Guide") 
+for more information.
 
 ## autoRIFT
 
-[AutoRIFT](https://github.com/leiyangleon/autoRIFT "https://github.com/leiyangleon/autoRIFT" ){target=_blank} produces a velocity map from
-observed motion using a feature tracking algorithm developed as part of the 
-[NASA MEaSUREs ITS_LIVE](https://its-live.jpl.nasa.gov/ "https://its-live.jpl.nasa.gov" ){target=_blank} project. 
+[AutoRIFT](https://github.com/leiyangleon/autoRIFT "https://github.com/leiyangleon/autoRIFT" ){target=_blank} 
+produces a velocity map from observed motion using a feature tracking algorithm developed as part of the 
+[NASA MEaSUREs ITS_LIVE](https://its-live.jpl.nasa.gov/ "https://its-live.jpl.nasa.gov" ){target=_blank} 
+project. 
 
-To learn more, visit the [ITS_LIVE project website](https://its-live.jpl.nasa.gov/ "https://its-live.jpl.nasa.gov" ){target=_blank}.
+To learn more, visit the 
+[ITS_LIVE project website](https://its-live.jpl.nasa.gov/ "https://its-live.jpl.nasa.gov" ){target=_blank}.


### PR DESCRIPTION
Once the RAiDER update has been implemented, this PR can be used to remove the warning message about ARIA GUNW On Demand not being available over Alaska. 

The changelog/version may need to be amended, depending on the timing of this release relative to other updates.