### PR TITLE
dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,17 @@ updates:
       interval: weekly
     labels:
       - bumpless
+    groups:
+      pip-deps:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     labels:
       - bumpless
+    groups:
+      github-actions-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
This repo has a few dependabot PRs open, and I want to experiment with using the `@dependabot ignore DEPENDENCY_NAME patch version` command for ignoring a problematic upgrade.

Makes the same change as https://github.com/ASFHyP3/hyp3/pull/2781