### PR TITLE
Reduce autoRIFT credits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.18]
+
+### Changed
+* The cost of autoRIFT jobs has been reduced back to 25 credits, from 50 credits, on the [credits](docs/using/credits.md) page. 
+
 ## [0.10.17]
 
 ### Changed

--- a/docs/using/credits.md
+++ b/docs/using/credits.md
@@ -46,7 +46,7 @@ allotment on jobs of that particular type.
 | {{ table_indent(count=2) }} 14 pairs                          |            105 | {{ max_jobs_per_month(105) }} |
 | {{ table_indent(count=2) }} 15 pairs                          |            110 | {{ max_jobs_per_month(110) }} |
 | [**AutoRIFT**](https://its-live.jpl.nasa.gov/){target=_blank} |                |                               |
-| {{ table_indent() }} Standard product (120-m pixel spacing)   |             50 |  {{ max_jobs_per_month(50) }} |
+| {{ table_indent() }} Standard product (120-m pixel spacing)   |             25 |  {{ max_jobs_per_month(25) }} |
 
 The credit cost of a given job is roughly proportional to the computational resources required to process the job,
 allowing us to distribute our resources more equitably.


### PR DESCRIPTION
Due to a performance fix in https://github.com/ASFHyP3/hyp3-autorift/pull/364, we can reduce the credits back to the previous value of 25.