### PR TITLE
add Sentinel-1D to InSAR naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.13.8]
+
+### Changed
+* Updated the InSAR Product Guide naming convention to include Sentinel-1D mission identifiers
+
 ## [0.13.7]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.13.9]
+
+### Changed
+* Updated product guide naming conventions to include Sentinel-1D mission identifiers
+
 ## [0.13.8]
 
 ### Changed
 * Dropped `polyfill.io` as a dependency
-
-## [0.13.8]
-
-### Changed
-* Updated the InSAR Product Guide naming convention to include Sentinel-1D mission identifiers
 
 ## [0.13.7]
 

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -220,7 +220,7 @@ following order, as illustrated in Figure 4.
 
 - The platform names, one of Sentinel-1A, Sentinel-1B, Sentinel-1C, or Sentinel-1D, are abbreviated with the letters `A`, `B`, `C`, or `D`
     - Two of these letters follow `S1`, indicating the platform(s) used to acquire the reference and 
-      secondary images, in that order (`S1AA`, `S1BA`, `S1AC`, `S1AD`, etc.)
+      secondary images, in that order (`S1AA`, `S1BA`, `S1AC`, `S1CD`, etc.)
 - The reference start date and time and the secondary start date and time, with the date and time 
   separated by the letter T
 - The polarizations for the pair, either HH or VV, the orbit type, and the days of separation for the pair

--- a/docs/guides/insar_product_guide.md
+++ b/docs/guides/insar_product_guide.md
@@ -218,9 +218,9 @@ HyP3 InSAR output is a zip file containing various files, including GeoTIFFs, PN
 The InSAR product names are packed with information pertaining to the processing of the data, presented in the 
 following order, as illustrated in Figure 4. 
 
-- The platform names, one of Sentinel-1A, Sentinel-1B, or Sentinel-1C, are abbreviated with the letters `A`, `B`, or `C`
+- The platform names, one of Sentinel-1A, Sentinel-1B, Sentinel-1C, or Sentinel-1D, are abbreviated with the letters `A`, `B`, `C`, or `D`
     - Two of these letters follow `S1`, indicating the platform(s) used to acquire the reference and 
-      secondary images, in that order (`S1AA`, `S1BA`, `S1AC`, etc.)
+      secondary images, in that order (`S1AA`, `S1BA`, `S1AC`, `S1AD`, etc.)
 - The reference start date and time and the secondary start date and time, with the date and time 
   separated by the letter T
 - The polarizations for the pair, either HH or VV, the orbit type, and the days of separation for the pair

--- a/docs/guides/rtc_product_guide.md
+++ b/docs/guides/rtc_product_guide.md
@@ -261,7 +261,7 @@ Example: S1A_IW_20180128T161201_DVP_RTC30_G_gpuned_FD6A
 
 | Element  | Definition                                                                   | Example  |
 |----------|------------------------------------------------------------------------------|----------|
-| x        | Sentinel-1 Platform: A, B, or C                                              | A        |
+| x        | Sentinel-1 Platform: A, B, C, or D                                           | A        |
 | yy       | Beam Mode                                                                    | IW       |
 | aaaaaaaa | Start Year-Month-Day                                                         | 20180128 |
 | bbbbbb   | Start Hour-Minute-Second                                                     | 161201   |


### PR DESCRIPTION
Updates the InSAR product guide naming convention to include Sentinel-1D mission identifiers.

