### PR TITLE
Document lack of S1D support in ISCE2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.13.9]
+
+### Changed 
+* Documented lack of support for Sentinel-1D acquisitions in ISCE2 software
+
 ## [0.13.8]
 
 ### Changed

--- a/docs/guides/burst_insar_product_guide.md
+++ b/docs/guides/burst_insar_product_guide.md
@@ -21,11 +21,15 @@ For those who would prefer to work at the scale of a full IW SLC, our original
 [On Demand InSAR](insar_product_guide.md){target=_blank} products are still available. These products have a larger 
 footprint, and are generated using [GAMMA software](https://www.gamma-rs.ch/software){target=_blank}.  If unsure of which InSAR processing option best fits your needs, visit our [ASF Sentinel-1 InSAR on Demand Product Comparison StoryMap](https://storymaps.arcgis.com/stories/6cb4f1c18558441bb9b4b11337515b53 "ASF Sentinel-1 InSAR On Demand Product Comparison"){target=_blank} to explore the capabilities, characteristics, and available products for each of ASF's On Demand InSAR options. 
 
-!!! tip "Sentinel-1C acquisitions now supported!" 
+!!! tip "Sentinel-1D acquisitions not yet supported" 
 
-    ISCE2 has been updated to support processing of data collected by Sentinel-1C. Users can now submit 
-    burst-based InSAR jobs for any available bursts from Sentinel-1 IW SLCs, regardless of the platform used 
-    to acquire the data.
+    ISCE2 software does not currently support processing Sentinel-1D acquisitions. Until the software package is 
+    updated, users will not be able to include Sentinel-1D bursts in pairs submitted for Burst InSAR 
+    processing. 
+
+    Users can submit full IW Sentinel-1D granules for processing to InSAR using the 
+    [On Demand InSAR](insar_product_guide.md "Sentinel-1 InSAR Product Guide") option, which leverages 
+    GAMMA software rather than ISCE2. 
 
 ## Burst InSAR Job Types
 

--- a/docs/guides/gunw_product_guide.md
+++ b/docs/guides/gunw_product_guide.md
@@ -103,6 +103,12 @@ ARIA-S1-GUNW jobs for On Demand processing.
 If the ARIA-S1-GUNW products you need are not available in the archive, you can use ASF's On Demand platform to submit 
 custom ARIA-S1-GUNW jobs for processing. 
 
+!!! warning "Sentinel-1D acquisitions not yet supported" 
+
+    ISCE2 software, which is used for processing ARIA GUNW products, does not currently support processing 
+    SLCs acquired by the newly launched Sentinel-1D platform. Until the software package is updated, users will 
+    not be able to submit ARIA-S1-GUNW jobs that include Sentinel-1D acquisitions for On-Demand processing.
+
 To order ARIA-S1-GUNW products using 
 [Vertex](https://search.asf.alaska.edu/#/?dataset=SENTINEL-1%20INTERFEROGRAM%20(BETA)), 
 select **ARIA-S1-GUNW** from the Dataset menu for a **Geographic Search**, and turn on the **On Demand** toggle switch. 

--- a/docs/guides/insar_product_guide_template.md
+++ b/docs/guides/insar_product_guide_template.md
@@ -71,12 +71,11 @@ Jobs can be submitted for processing using the
 [HyP3 Python SDK](https://hyp3-docs.asf.alaska.edu/using/sdk/ "https://hyp3-docs.asf.alaska.edu/using/sdk" ){target=_blank} 
 or the [HyP3 API](https://hyp3-docs.asf.alaska.edu/using/api/ "https://hyp3-docs.asf.alaska.edu/using/api" ){target=_blank}.
 
-!!! tip "InSAR Processing Now Supports Sentinel-1C!" 
+!!! warning "Sentinel-1D Support for InSAR Processing" 
 
-    GAMMA and ISCE2 software have both been updated to support Sentinel-1C acquisitions as input for InSAR processing. 
-    Users can now use any Sentinel-1 IW SLCs in the archive, including those acquired by Sentinel-1C, as input for 
-    either [On Demand InSAR](insar_product_guide.md) or [On Demand Burst InSAR](burst_insar_product_guide.md) 
-    processing.
+    GAMMA software supports Sentinel-1D acquisitions as input for InSAR processing, but ISCE2 software currently does 
+    not. Until ISCE2 is updated, users will only be able to submit jobs including Sentinel-1D SLCs for processing 
+    using [On Demand InSAR](insar_product_guide.md), not [On Demand Burst InSAR](burst_insar_product_guide.md).
 
 ### Vertex
 InSAR pairs are selected in [Vertex](https://search.asf.alaska.edu/#/ "https://search.asf.alaska.edu" ){target=_blank} using either the [Baseline Search](https://docs.asf.alaska.edu/vertex/baseline/ "https://docs.asf.alaska.edu/vertex/baseline" ){target=_blank} or the [SBAS Search](https://docs.asf.alaska.edu/vertex/sbas/ "https://docs.asf.alaska.edu/vertex/sbas" ){target=_blank} interface. The process of selecting pairs is the same for both IW SLC products and individual SLC bursts, but you will need to select the appropriate dataset when searching for content. As illustrated below, select the **Sentinel-1** option in the Dataset menu to search for IW SLC products, and select the **S1 Bursts** option to search for individual SLC bursts.

--- a/docs/products.md
+++ b/docs/products.md
@@ -115,6 +115,16 @@ sets of up to 15 contiguous along-track bursts to generate a single output inter
 [Sentinel-1 Burst InSAR Product Guide](guides/burst_insar_product_guide.md "Sentinel-1 Burst InSAR Product Guide") 
 for more information.
 
+!!! warning "Sentinel-1D acquisitions not yet supported in ISCE2" 
+
+    ISCE2 software does not currently support processing Sentinel-1D acquisitions. Until the software package is 
+    updated, users will not be able to include Sentinel-1D bursts in pairs submitted for Burst InSAR 
+    processing. 
+
+    Users can submit full IW Sentinel-1D granules for processing to InSAR using the 
+    [On Demand InSAR](insar_product_guide.md "Sentinel-1 InSAR Product Guide") option, which leverages 
+    GAMMA software rather than ISCE2. 
+
 For step-by-step instructions on searching for, ordering and downloading On Demand Burst InSAR products, visit our 
 [Burst-Based InSAR for Sentinel-1 On Demand](https://storymaps.arcgis.com/stories/191bf1b6962c402086807390b3ce63b0 "Burst-Based InSAR for Sentinel-1 On Demand StoryMap" ){target=_blank} 
 tutorial.


### PR DESCRIPTION
This PR documents the lack of S1D support in ISCE2. It does also indicate that the GAMMA workflows support S1D, so that functionality should be verified before this content is released. It could potentially be a combined release along with https://github.com/ASFHyP3/hyp3-docs/pull/724 if the timing works out.