### PR TITLE
update docs to indicate support for S1D in burst-based InSAR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.13.11]
+
+### Changed
+* Updated messages about Sentinel-1D support to indicate that burst-based InSAR now supports S1D as input
+* Clarified that ARIA-S1-GUNW processing does not yet support Sentinel-1D acquisitions
+
 ## [0.13.10]
 
 ### Changed

--- a/docs/guides/burst_insar_product_guide.md
+++ b/docs/guides/burst_insar_product_guide.md
@@ -21,15 +21,11 @@ For those who would prefer to work at the scale of a full IW SLC, our original
 [On Demand InSAR](insar_product_guide.md){target=_blank} products are still available. These products have a larger 
 footprint, and are generated using [GAMMA software](https://www.gamma-rs.ch/software){target=_blank}.  If unsure of which InSAR processing option best fits your needs, visit our [ASF Sentinel-1 InSAR on Demand Product Comparison StoryMap](https://storymaps.arcgis.com/stories/6cb4f1c18558441bb9b4b11337515b53 "ASF Sentinel-1 InSAR On Demand Product Comparison"){target=_blank} to explore the capabilities, characteristics, and available products for each of ASF's On Demand InSAR options. 
 
-!!! tip "Sentinel-1D acquisitions not yet supported" 
+!!! tip "Sentinel-1D acquisitions now supported!" 
 
-    ISCE2 software does not currently support processing Sentinel-1D acquisitions. Until the software package is 
-    updated, users will not be able to include Sentinel-1D bursts in pairs submitted for Burst InSAR 
-    processing. 
-
-    Users can submit full IW Sentinel-1D granules for processing to InSAR using the 
-    [On Demand InSAR](insar_product_guide.md "Sentinel-1 InSAR Product Guide") option, which leverages 
-    GAMMA software rather than ISCE2. 
+    ISCE2 has been updated to support processing of data collected by Sentinel-1D. Users can now submit 
+    burst-based InSAR jobs for any available bursts from Sentinel-1 IW SLCs, regardless of the platform used 
+    to acquire the data.
 
 ## Burst InSAR Job Types
 

--- a/docs/guides/gunw_product_guide.md
+++ b/docs/guides/gunw_product_guide.md
@@ -105,9 +105,9 @@ custom ARIA-S1-GUNW jobs for processing.
 
 !!! warning "Sentinel-1D acquisitions not yet supported" 
 
-    ISCE2 software, which is used for processing ARIA GUNW products, does not currently support processing 
-    SLCs acquired by the newly launched Sentinel-1D platform. Until the software package is updated, users will 
-    not be able to submit ARIA-S1-GUNW jobs that include Sentinel-1D acquisitions for On-Demand processing.
+    The code used for processing ARIA-S1-GUNW products does not currently support processing SLCs acquired by the 
+    Sentinel-1D platform. Until the code has been updated to use the newest version of ISCE2, users will 
+    not be able to submit ARIA-S1-GUNW jobs that include Sentinel-1D acquisitions for On Demand processing.
 
 To order ARIA-S1-GUNW products using 
 [Vertex](https://search.asf.alaska.edu/#/?dataset=SENTINEL-1%20INTERFEROGRAM%20(BETA)), 

--- a/docs/guides/insar_product_guide_template.md
+++ b/docs/guides/insar_product_guide_template.md
@@ -71,11 +71,12 @@ Jobs can be submitted for processing using the
 [HyP3 Python SDK](https://hyp3-docs.asf.alaska.edu/using/sdk/ "https://hyp3-docs.asf.alaska.edu/using/sdk" ){target=_blank} 
 or the [HyP3 API](https://hyp3-docs.asf.alaska.edu/using/api/ "https://hyp3-docs.asf.alaska.edu/using/api" ){target=_blank}.
 
-!!! warning "Sentinel-1D Support for InSAR Processing" 
+!!! tip "InSAR Processing Now Supports Sentinel-1D!" 
 
-    GAMMA software supports Sentinel-1D acquisitions as input for InSAR processing, but ISCE2 software currently does 
-    not. Until ISCE2 is updated, users will only be able to submit jobs including Sentinel-1D SLCs for processing 
-    using [On Demand InSAR](insar_product_guide.md), not [On Demand Burst InSAR](burst_insar_product_guide.md).
+    GAMMA and ISCE2 software have both been updated to support Sentinel-1D acquisitions as input for InSAR processing. 
+    Users can now use any Sentinel-1 IW SLCs in the archive, including those acquired by Sentinel-1D, as input for 
+    either [On Demand InSAR](insar_product_guide.md) or [On Demand Burst InSAR](burst_insar_product_guide.md) 
+    processing.
 
 ### Vertex
 InSAR pairs are selected in [Vertex](https://search.asf.alaska.edu/#/ "https://search.asf.alaska.edu" ){target=_blank} using either the [Baseline Search](https://docs.asf.alaska.edu/vertex/baseline/ "https://docs.asf.alaska.edu/vertex/baseline" ){target=_blank} or the [SBAS Search](https://docs.asf.alaska.edu/vertex/sbas/ "https://docs.asf.alaska.edu/vertex/sbas" ){target=_blank} interface. The process of selecting pairs is the same for both IW SLC products and individual SLC bursts, but you will need to select the appropriate dataset when searching for content. As illustrated below, select the **Sentinel-1** option in the Dataset menu to search for IW SLC products, and select the **S1 Bursts** option to search for individual SLC bursts.

--- a/docs/products.md
+++ b/docs/products.md
@@ -115,16 +115,6 @@ sets of up to 15 contiguous along-track bursts to generate a single output inter
 [Sentinel-1 Burst InSAR Product Guide](guides/burst_insar_product_guide.md "Sentinel-1 Burst InSAR Product Guide") 
 for more information.
 
-!!! warning "Sentinel-1D acquisitions not yet supported in ISCE2" 
-
-    ISCE2 software does not currently support processing Sentinel-1D acquisitions. Until the software package is 
-    updated, users will not be able to include Sentinel-1D bursts in pairs submitted for Burst InSAR 
-    processing. 
-
-    Users can submit full IW Sentinel-1D granules for processing to InSAR using the 
-    [On Demand InSAR](insar_product_guide.md "Sentinel-1 InSAR Product Guide") option, which leverages 
-    GAMMA software rather than ISCE2. 
-
 For step-by-step instructions on searching for, ordering and downloading On Demand Burst InSAR products, visit our 
 [Burst-Based InSAR for Sentinel-1 On Demand](https://storymaps.arcgis.com/stories/191bf1b6962c402086807390b3ce63b0 "Burst-Based InSAR for Sentinel-1 On Demand StoryMap" ){target=_blank} 
 tutorial.


### PR DESCRIPTION
TOOL-4893

Updates the burst InSAR docs to show Sentinel-1D as supported, now that hyp3-isce2 ships ISCE2 v2.6.5 (v4.1.4, backported to v3.0.2). GUNW keeps its note.