### PR TITLE
Adjustments to image layer section

### DIFF
--- a/docs/guides/burst_insar_product_guide.md
+++ b/docs/guides/burst_insar_product_guide.md
@@ -408,7 +408,7 @@ output product:
 - The *normalized coherence* file contains pixel values that range from 0.0 to 1.0, with 0.0 being completely non-coherent and 1.0 being perfectly coherent.
 - The *unwrapped geocoded interferogram* file shows the results of the phase unwrapping process. Negative values indicate movement towards the sensor, and positive values indicate movement away from the sensor. This is the main interferogram output.
 - The *wrapped geocoded interferogram* file indicates the interferogram phase after applying the adaptive filter immediately before unwrapping. Values range from negative pi to positive pi.
-- An *amplitude* image is included for products `INSAR_ISCE_MULTI_BURST` jobs, the final product includes the interferogram amplitude as a single-band GeoTIFF along with browse KMZ files for both the wrapped phase and amplitude.
+- An interferogram *amplitude* image is included for products generated using the `INSAR_ISCE_MULTI_BURST` job type.
 - The *connected components* file delineates regions unwrapped as contiguous units by the SNAPHU unwrapping algorithm.
 - The *look vectors* theta (θ) and phi (φ) describe the elevation and orientation angles of the look vector in radians. The look vectors refer to the look direction back towards the sensor.
     - The *lv_theta* (θ) file indicates the SAR look vector elevation angle (in radians) at each pixel, ranging from -π/2 (down) to π/2 (up). The look vector elevation angle is defined as the angle between the horizontal surface and the look vector with positive angles indicating sensor positions above the surface.

--- a/docs/guides/burst_insar_product_guide.md
+++ b/docs/guides/burst_insar_product_guide.md
@@ -408,6 +408,7 @@ output product:
 - The *normalized coherence* file contains pixel values that range from 0.0 to 1.0, with 0.0 being completely non-coherent and 1.0 being perfectly coherent.
 - The *unwrapped geocoded interferogram* file shows the results of the phase unwrapping process. Negative values indicate movement towards the sensor, and positive values indicate movement away from the sensor. This is the main interferogram output.
 - The *wrapped geocoded interferogram* file indicates the interferogram phase after applying the adaptive filter immediately before unwrapping. Values range from negative pi to positive pi.
+- An *amplitude* image is included for products `INSAR_ISCE_MULTI_BURST` jobs, the final product includes the interferogram amplitude as a single-band GeoTIFF along with browse KMZ files for both the wrapped phase and amplitude.
 - The *connected components* file delineates regions unwrapped as contiguous units by the SNAPHU unwrapping algorithm.
 - The *look vectors* theta (θ) and phi (φ) describe the elevation and orientation angles of the look vector in radians. The look vectors refer to the look direction back towards the sensor.
     - The *lv_theta* (θ) file indicates the SAR look vector elevation angle (in radians) at each pixel, ranging from -π/2 (down) to π/2 (up). The look vector elevation angle is defined as the angle between the horizontal surface and the look vector with positive angles indicating sensor positions above the surface.
@@ -438,7 +439,9 @@ These range-doppler files are not included in products generated using `INSAR_IS
 as the individual bursts are already merged together.
 
 An *unwrapped phase browse image* is included for the unwrapped (unw_phase) phase file, which is in PNG format 
-and is 2048 pixels wide. For jobs processed using `INSAR_ISCE_MULTI_BURST`, the final product includes the interferogram amplitude as a single-band GeoTIFF along with browse KMZ files for both the wrapped phase and amplitude.
+and is 2048 pixels wide.
+
+For jobs processed using `INSAR_ISCE_MULTI_BURST`, **KMZ browse images** are included for the **wrapped phase** and **amplitude** images.
 
 The tags and extensions used and example file names for each raster are listed in Table 2 below.
 
@@ -448,7 +451,7 @@ The tags and extensions used and example file names for each raster are listed i
 
 | Extension              | Description                         | Example (single-burst)<br/>⸻<br/>Example (multi-burst)                           |
 |------------------------|-------------------------------------|----------------------------------------------------------------------------------|
-| _amp.tif               | Amplitude file                      | {{ base_name_mb }}_amp.tif                                                          |
+| _amp.tif               | Amplitude file                      | {{ base_name_mb }}_amp.tif                                                       |
 | _conncomp.tif          | Connected Components                | {{ base_name }}_conncomp.tif<br/>⸻<br/>{{ base_name_mb }}_conncomp.tif           |
 | _corr.tif              | Normalized coherence file           | {{ base_name }}_corr.tif<br/>⸻<br/>{{ base_name_mb }}_corr.tif                   |
 | _unw_phase.tif         | Unwrapped geocoded interferogram    | {{ base_name }}_unw_phase.tif<br/>⸻<br/>{{ base_name_mb }}_unw_phase.tif         |
@@ -462,8 +465,8 @@ The tags and extensions used and example file names for each raster are listed i
 | _los_rdr.tif           | Range-Doppler look vectors          | {{ base_name }}_los_rdr.tif                                                      |
 | _wrapped_phase_rdr.tif | Wrapped Range-Doppler interferogram | {{ base_name }}_wrapped_phase_rdr.tif                                            |
 | _unw_phase.png         | Unwrapped phase browse image        | {{ base_name }}_unw_phase.png<br/>⸻<br/>{{ base_name_mb }}_unw_phase.png         |
-| _amp.kmz               | Amplitude KMZ browse image          | {{ base_name_mb }}_amp.kmz         |
-| _wrapped_phase.kmz     | Wrapped phase KMZ browse image      | {{ base_name_mb }}_wrapped_phase.kmz         |
+| _amp.kmz               | Amplitude KMZ browse image          | {{ base_name_mb }}_amp.kmz                                                       |
+| _wrapped_phase.kmz     | Wrapped phase KMZ browse image      | {{ base_name_mb }}_wrapped_phase.kmz                                             |
 
 *Table 2: Image files in product package*
 


### PR DESCRIPTION
This just rearranges the location of the description of the newly added layers to align with the existing groupings (GeoTIFFs first, then browse after). I'd hoped to get it in before the last release; not sure if it's worth doing another one. 